### PR TITLE
fix person, ensure card can be setup as a person card

### DIFF
--- a/src/components/card.jsx
+++ b/src/components/card.jsx
@@ -2,13 +2,20 @@ import { cva } from 'class-variance-authority'
 
 import { cn } from '../lib/utils'
 import Button from './button'
+import Heading from './heading'
 
 const cardVariants = cva(
   'flex w-full max-w-md flex-col items-center gap-4 rounded-2xl pb-6 leading-[normal]',
   {
     variants: {
+      layout: {
+        'Left aligned': 'items-start text-left',
+        'Center aligned': 'items-center text-center',
+        'Right aligned': 'items-end text-right',
+      },
       textColor: {
-        Dark: null,
+        Default: null,
+        Dark: 'text-blue-700',
         Light: 'text-white',
       },
       image: {
@@ -16,22 +23,27 @@ const cardVariants = cva(
         false: 'pt-8',
       },
     },
+    defaultVariants: {
+      textColor: 'Default',
+    },
   }
 )
 
 const Card = ({
+  altText = '',
   backgroundColor = '#ffffff',
   backgroundColorOnHover = '#E2E8F0',
   className,
   image,
   heading,
   headingElement = 'h2',
+  layout = 'Left aligned',
   link,
   linkLabel,
+  linkVariant = 'link',
   text,
   textColor,
 }) => {
-  const Heading = headingElement
   const cardBackgroundClassName = `card-${backgroundColor.substring(1)}`
   const cardBackgroundClassNameOnHover = `card-${backgroundColorOnHover.substring(1)}`
 
@@ -49,7 +61,7 @@ const Card = ({
       </style>
       <div
         className={cn(
-          cardVariants({ textColor, image: !!image }),
+          cardVariants({ layout, textColor, image: !!image }),
           cardBackgroundClassName,
           cardBackgroundClassNameOnHover,
           className
@@ -57,17 +69,25 @@ const Card = ({
       >
         {image && (
           <img
+            alt={altText}
             className="w-full rounded-2xl object-cover object-center"
             src={image}
           />
         )}
         <div className="px-6 pt-2">
           {heading && (
-            <Heading className="mb-4 text-lg font-bold">{heading}</Heading>
+            <Heading
+              className="mb-2"
+              heading={heading}
+              headingElement={headingElement}
+              headingSize="Small"
+              layout={layout}
+              textColor={textColor}
+            />
           )}
           {text && <p className="mb-4 leading-6">{text}</p>}
           {link && linkLabel && (
-            <Button link={link} variant="link">
+            <Button link={link} variant={linkVariant}>
               {linkLabel}
             </Button>
           )}

--- a/src/components/card.stories.jsx
+++ b/src/components/card.stories.jsx
@@ -5,6 +5,10 @@ const meta = {
   title: 'Components/Card',
   component: Card,
   argTypes: {
+    layout: {
+      options: ['Left aligned', 'Center aligned', 'Right aligned'],
+      control: { type: 'select' },
+    },
     headingElement: {
       options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
       control: { type: 'select' },
@@ -12,6 +16,20 @@ const meta = {
     textColor: {
       options: ['Dark', 'Light'],
       control: { type: 'select' },
+    },
+    linkVariant: {
+      control: 'select',
+      options: [
+        'solid',
+        'outlineDark',
+        'outlineLight',
+        'ghost',
+        'ghostNeutral',
+        'ghostLight',
+        'link',
+        'linkUnderline',
+        'linkDark',
+      ],
     },
   },
 }
@@ -23,7 +41,6 @@ export const Default = {
     heading: 'Engaging title that represents the content.',
     headingElement: 'h2',
     text: "Some quick example text to build on the card title and make up the bulk of the card's content.",
-    textColor: 'Dark',
     linkLabel: 'Learn More',
     link: '#',
     image: imagePlaceholder,

--- a/src/components/people/index.jsx
+++ b/src/components/people/index.jsx
@@ -1,0 +1,4 @@
+export { default as Author } from './author'
+export { default as Person } from './person'
+export { default as PersonCard } from './personCard'
+export { default as PersonSection } from './personSection'

--- a/src/components/people/people.stories.jsx
+++ b/src/components/people/people.stories.jsx
@@ -1,15 +1,27 @@
+import Card from '../card'
 import CardContainer from '../cardContainer'
-import Author from './author'
-import PersonCard from './personCard'
-import PersonSection from './PersonSection'
+import { Author, Person, PersonCard, PersonSection } from './index'
 
 const meta = {
   title: 'Components/People',
-  component: null,
-  argTypes: {},
+  component: Person,
+  tags: ['autodocs'],
 }
 
 export default meta
+
+export const PersonDefault = {
+  args: {
+    name: 'Garth Brooks',
+    title: 'Boss / Country music',
+    avatar: '/src/assets/images/person.jpg',
+    avatarAltText: 'test alt text',
+    headingElement: 'h4',
+  },
+  render: (args) => {
+    return <Person {...args} />
+  },
+}
 
 export const PersonCardDefault = {
   args: {
@@ -21,6 +33,21 @@ export const PersonCardDefault = {
   },
   render: (args) => {
     return <PersonCard {...args} />
+  },
+}
+
+export const PersonUsingCard = {
+  args: {},
+  render: () => {
+    return (
+      <Card
+        heading="Garth Brooks"
+        headingElement="h2"
+        image="/src/assets/images/person.jpg"
+        text="Boss / Country music"
+        textColor="Dark"
+      ></Card>
+    )
   },
 }
 
@@ -44,6 +71,70 @@ export const PersonCardSection = {
     const cardsArray = Array(args.previewCardCount).fill(null)
     const cards = cardsArray.map((_, index) => {
       return <PersonCard key={index} {...args} />
+    })
+    return <CardContainer {...args}>{cards}</CardContainer>
+  },
+}
+
+export const PersonUsingCardSection = {
+  args: {
+    headingElement: 'h3',
+    cardLayout: '4 columns',
+    previewCardCount: 4,
+    layout: 'Center aligned',
+    preHeading: 'Team',
+    heading: 'Meet our leadership.',
+    headingSize: 'Medium',
+    textColor: 'Dark',
+    previewCardType: 'Feature Card',
+  },
+  render: (args) => {
+    const cardsArray = Array(args.previewCardCount).fill(null)
+    const cards = cardsArray.map((_, index) => {
+      return (
+        <Card
+          key={index}
+          altText={'test alt text'}
+          heading="Garth Brooks"
+          headingElement="h2"
+          image="/src/assets/images/person.jpg"
+          text="Boss / Country music"
+          textColor="Dark"
+        ></Card>
+      )
+    })
+    return <CardContainer {...args}>{cards}</CardContainer>
+  },
+}
+
+export const PersonUsingCardSectionLight = {
+  args: {
+    headingElement: 'h3',
+    cardLayout: '4 columns',
+    previewCardCount: 4,
+    layout: 'Center aligned',
+    preHeading: 'Team',
+    heading: 'Meet our leadership.',
+    headingSize: 'Medium',
+    textColor: 'Dark',
+    previewCardType: 'Feature Card',
+  },
+  render: (args) => {
+    const cardsArray = Array(args.previewCardCount).fill(null)
+    const cards = cardsArray.map((_, index) => {
+      return (
+        <Card
+          key={index}
+          altText="test alt text"
+          backgroundColor="#000000"
+          backgroundColorOnHover="#333333"
+          heading="Garth Brooks"
+          headingElement="h2"
+          image="/src/assets/images/person.jpg"
+          text="Boss / Country music"
+          textColor="Light"
+        ></Card>
+      )
     })
     return <CardContainer {...args}>{cards}</CardContainer>
   },

--- a/src/components/people/person.jsx
+++ b/src/components/people/person.jsx
@@ -50,12 +50,22 @@ function Person({
           src={avatar}
         />
       )}
-      <div className={cn('mt-2 flex flex-col gap-1 sm:mt-4', textClasses)}>
-        <Heading className={cn(headingVariants({ textColor: headingColor }))}>
-          {name}
-        </Heading>
-        <p className={cn(titleVariants({ textColor: titleColor }))}>{title}</p>
-      </div>
+      {(name || title) && (
+        <div className={cn('mt-2 flex flex-col gap-1 sm:mt-4', textClasses)}>
+          {name && (
+            <Heading
+              className={cn(headingVariants({ textColor: headingColor }))}
+            >
+              {name}
+            </Heading>
+          )}
+          {title && (
+            <p className={cn(titleVariants({ textColor: titleColor }))}>
+              {title}
+            </p>
+          )}
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Make sure standard card can look be used with a person card.
We may no longer need the PersonCard and it might be good to have additional styles passed through to image as image styles to get the rounded avatar look. Keeping all the components for now though in case it's needed.

Still working off of imports. Still normalizing to make sure all the examples can work off of the one main components. Card and Feature Card remain the same.

Works off the premise that default text is null which falls back to body color. Dark text is set to blue. This was the only way to get the pass through colors to all work with heading element and cards, though it's possible the user may be able to define their own specific text color making this moot.

Person using card and card section.
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/cfe16606-ac2a-4c29-9d99-e62f6605d236" />

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/9e175a98-2f1d-4ff2-9f41-79f3eed1f68a" />

