### PR TITLE
expand testimonal usage, cleanup

### DIFF
--- a/src/components/testimonial/testimonial.jsx
+++ b/src/components/testimonial/testimonial.jsx
@@ -1,7 +1,67 @@
 import { cva } from 'class-variance-authority'
 
+import { cn } from '../../lib/utils'
+
+const cardVariants = cva(
+  'flex flex-col gap-2 border-l-2 border-l-gray-200 pl-3 leading-[normal]',
+  {
+    variants: {
+      layout: {
+        'Left aligned': 'items-start text-left',
+        'Center aligned': 'items-center text-center',
+        'Right aligned': 'items-end text-right',
+      },
+      textColor: {
+        Dark: '',
+        Light: 'text-white',
+      },
+    },
+    defaultVariants: {
+      layout: 'Left aligned',
+    },
+  }
+)
+
+const textVariants = cva('max-w-3xl', {
+  variants: {
+    textSize: {
+      Large: 'text-xl',
+      Medium: 'text-lg',
+      Small: 'text-base',
+    },
+  },
+})
+
+const nameVariants = cva('font-bold', {
+  variants: {
+    textSize: {
+      Large: 'text-base',
+      Medium: 'text-sm',
+      Small: 'text-xs',
+    },
+  },
+})
+
+const roleVariants = cva('text-sm', {
+  variants: {
+    textSize: {
+      Large: 'text-base',
+      Medium: 'text-sm',
+      Small: 'text-xs',
+    },
+    textColor: {
+      Dark: 'text-drupal-gray-default',
+      Light: 'text-gray-300',
+    },
+  },
+})
+
 export default function Testimonial({
   avatarAltText,
+  backgroundColor = '',
+  backgroundColorOnHover = '',
+  className,
+  layout,
   name,
   role,
   organization,
@@ -10,56 +70,36 @@ export default function Testimonial({
   textColor = 'Dark',
   textSize = 'Large',
 }) {
-  const textVariants = cva('max-w-3xl', {
-    variants: {
-      textSize: {
-        Large: 'text-xl',
-        Medium: 'text-lg',
-        Small: 'text-base',
-      },
-    },
-  })
-
-  const nameVariants = cva('font-bold', {
-    variants: {
-      textSize: {
-        Large: 'text-base',
-        Medium: 'text-sm',
-        Small: 'text-xs',
-      },
-    },
-  })
-
-  const roleVariants = cva('text-sm', {
-    variants: {
-      textSize: {
-        Large: 'text-base',
-        Medium: 'text-sm',
-        Small: 'text-xs',
-      },
-      textColor: {
-        Dark: 'text-drupal-gray-default',
-        Light: 'text-white',
-      },
-    },
-  })
-
   return (
-    <div className="flex flex-col gap-2 border-l-2 border-l-gray-200 pl-2">
-      <blockquote className={textVariants({ textSize })}>
-        <p>{text}</p>
-      </blockquote>
-      <div className="flex items-center gap-4">
-        <img
-          alt={avatarAltText}
-          className="h-10 w-10 rounded-full object-contain"
-          src={avatar}
-        />
-        <div className="flex flex-col gap-1">
-          <p className={nameVariants({ textSize })}>{name}</p>
-          <p
-            className={roleVariants({ textColor, textSize })}
-          >{`${role} | ${organization}`}</p>
+    <div
+      className={cn(
+        'rounded-xl',
+        'p-4',
+        'bg-[var(--color-bg)]',
+        'hover:bg-[var(--color-bg-hover)]',
+        className
+      )}
+      style={{
+        '--color-bg': backgroundColor,
+        '--color-bg-hover': backgroundColorOnHover,
+      }}
+    >
+      <div className={cn(cardVariants({ layout, textColor }))}>
+        <blockquote className={textVariants({ textSize })}>
+          <p>{text}</p>
+        </blockquote>
+        <div className="flex items-center gap-4">
+          <img
+            alt={avatarAltText}
+            className="h-10 w-10 rounded-full object-contain"
+            src={avatar}
+          />
+          <div className="flex flex-col gap-1">
+            <p className={nameVariants({ textSize })}>{name}</p>
+            <p
+              className={roleVariants({ textColor, textSize })}
+            >{`${role} | ${organization}`}</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/testimonial/testimonial.stories.jsx
+++ b/src/components/testimonial/testimonial.stories.jsx
@@ -1,5 +1,5 @@
 import CardContainer from '../cardContainer'
-import TestimonialCard from './testimonialCard'
+import Testimonial from './testimonial'
 import TestimonialSection from './testimonialSection'
 
 const meta = {
@@ -41,7 +41,7 @@ export const TestimonialCardDefault = {
   },
   render: (args) => {
     return (
-      <TestimonialCard
+      <Testimonial
         avatar={args.avatar}
         avatarAltText={args.avatarAltText}
         name={args.name}
@@ -49,6 +49,35 @@ export const TestimonialCardDefault = {
         role={args.role}
         text={args.text}
         textSize={args.textSize}
+      />
+    )
+  },
+}
+
+export const TestimonialCardDark = {
+  args: {
+    backgroundColor: '#000000',
+    backgroundColorOnHover: '#333333',
+    name: 'Garth Brooks',
+    role: 'Boss',
+    organization: 'Country music',
+    text: 'Truly one of the products of all time.',
+    avatar: '/src/assets/images/acquia-logo.svg',
+    avatarAltText: 'test alt text',
+    textSize: 'Small',
+    textColor: 'Light',
+  },
+  render: (args) => {
+    return (
+      <Testimonial
+        avatar={args.avatar}
+        avatarAltText={args.avatarAltText}
+        name={args.name}
+        organization={args.organization}
+        role={args.role}
+        text={args.text}
+        textSize={args.textSize}
+        {...args}
       />
     )
   },
@@ -72,7 +101,7 @@ export const TestimonialContainer = {
     const cardsArray = Array(args.previewCardCount).fill(null)
     const cards = cardsArray.map((_, index) => {
       return (
-        <TestimonialCard
+        <Testimonial
           key={`logo-card-${index}`}
           avatar="/src/assets/images/acquia-logo.svg"
           avatarAltText="test alt text"

--- a/src/components/testimonial/testimonialCard.jsx
+++ b/src/components/testimonial/testimonialCard.jsx
@@ -1,9 +1,0 @@
-import Testimonial from './testimonial'
-
-export default function TestimonialCard({ ...props }) {
-  return (
-    <div className="align-center flex min-h-45 max-w-70 flex-col justify-center gap-4 rounded-2xl bg-white p-4 leading-[normal]">
-      <Testimonial textSize="Small" {...props} />
-    </div>
-  )
-}


### PR DESCRIPTION
Make testimonial more reusable
Add more examples
No longer need separate card component after tweaks, so removing.

<img width="933" alt="image" src="https://github.com/user-attachments/assets/96015c39-7941-4ad9-bd34-88441237fb3e" />
