### PR TITLE
 use colors from global theme

### DIFF
--- a/src/components/breadcrumb.jsx
+++ b/src/components/breadcrumb.jsx
@@ -1,29 +1,49 @@
-const Breadcrumb = ({ links }) => {
+import { cva } from 'class-variance-authority'
+
+import { cn } from '../lib/utils'
+
+const textVariants = cva('', {
+  variants: {
+    textColor: {
+      Dark: 'text-black',
+      Light: 'text-white',
+    },
+    textSize: {
+      Large: 'text-lg',
+      Medium: 'text-base',
+      Small: 'text-sm',
+    },
+  },
+})
+
+const Breadcrumb = ({ links, textColor, textSize }) => {
   return (
     links && (
-      <nav aria-labelledby="system-breadcrumb">
-        <h2 className="sr-only" id="system-breadcrumb">
-          Breadcrumb
-        </h2>
-        <ol className="flex items-center whitespace-nowrap">
+      <nav aria-label="Breadcrumbs">
+        <ol
+          className={cn(
+            'flex items-center whitespace-nowrap',
+            textVariants({ textColor, textSize })
+          )}
+        >
           {links.map(({ key, text, url }, index) => (
             <li key={key} className="inline-flex items-center">
               {url ? (
                 <a
-                  className="flex items-center p-0 text-sm text-gray-900 hover:text-primary-600 hover:underline hover:underline-offset-3 focus:text-primary-600 focus-visible:rounded-lg focus-visible:border-transparent focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 active:text-primary-800"
+                  className="text-sm p-0 focus-visible:rounded-lg text-gray-900 hover:text-primary-600 hover:underline hover:underline-offset-3 focus:text-primary-600 focus-visible:border-transparent focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 active:text-primary-800"
                   href={url}
                 >
                   {text}
                 </a>
               ) : (
-                <span className="inline-flex items-center truncate text-sm font-semibold text-gray-800">
+                <span className="text-sm font-semibold inline-flex items-center truncate">
                   {text}
                 </span>
               )}
               {index !== links.length - 1 && (
                 <svg
                   aria-hidden="true"
-                  className="mx-2 size-4 shrink-0 text-gray-400 dark:text-neutral-600"
+                  className="mx-2 size-4 shrink-0 text-gray-400"
                   fill="none"
                   height="24"
                   stroke="currentColor"

--- a/src/components/button.jsx
+++ b/src/components/button.jsx
@@ -7,7 +7,6 @@ const baseStyles = {
   focus:
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:no-underline focus-visible:outline-primary-500 focus-visible:rounded-lg focus-visible:border-transparent',
   svg: '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
-  link: 'text-primary-600 hover:text-primary-800 hover:underline hover:underline-offset-2 focus:text-primary-800 active:text-primary-900',
 }
 
 const buttonVariants = cva(

--- a/src/components/button.jsx
+++ b/src/components/button.jsx
@@ -7,11 +7,12 @@ const baseStyles = {
   focus:
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:no-underline focus-visible:outline-primary-500 focus-visible:rounded-lg focus-visible:border-transparent',
   svg: '[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  link: 'text-primary-600 hover:text-primary-800 hover:underline hover:underline-offset-2 focus:text-primary-800 active:text-primary-900',
 }
 
 const buttonVariants = cva(
   cn(
-    'inline-flex cursor-pointer items-center justify-center gap-2 rounded-lg px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors',
+    'gap-2 rounded-lg px-4 py-3 text-sm font-medium inline-flex cursor-pointer items-center justify-center whitespace-nowrap transition-colors',
     baseStyles.disable,
     baseStyles.focus,
     baseStyles.svg
@@ -39,7 +40,7 @@ const buttonVariants = cva(
         linkLight:
           'p-0 text-white hover:text-primary-100 hover:underline hover:underline-offset-3 focus:text-primary-100 active:text-primary-200',
         navLinkDark:
-          'rounded-none border-s-0 border-transparent hover:border-primary-600 hover:text-primary-600 focus:border-primary-600 focus:text-primary-600 active:border-primary-800 active:text-primary-800 md:px-1 md:py-3',
+          'md:px-1 md:py-3 rounded-none border-s-0 border-transparent hover:border-primary-600 hover:text-primary-600 focus:border-primary-600 focus:text-primary-600 active:border-primary-800 active:text-primary-800',
       },
     },
     defaultVariants: {

--- a/src/components/card.jsx
+++ b/src/components/card.jsx
@@ -5,7 +5,7 @@ import Button from './button'
 import Heading from './heading'
 
 const cardVariants = cva(
-  'flex w-full max-w-md flex-col items-center gap-4 rounded-2xl pb-6 leading-[normal]',
+  'max-w-md gap-4 rounded-2xl pb-6 flex w-full flex-col items-center leading-[normal]',
   {
     variants: {
       layout: {
@@ -15,7 +15,7 @@ const cardVariants = cva(
       },
       textColor: {
         Default: null,
-        Dark: 'text-blue-700',
+        Dark: 'text-primary-dark',
         Light: 'text-white',
       },
       image: {
@@ -70,7 +70,7 @@ const Card = ({
         {image && (
           <img
             alt={altText}
-            className="w-full rounded-2xl object-cover object-center"
+            className="rounded-2xl w-full object-cover object-center"
             src={image}
           />
         )}

--- a/src/components/carousel/Carousel.jsx
+++ b/src/components/carousel/Carousel.jsx
@@ -19,9 +19,9 @@ const Carousel = ({ items }) => {
 
   return (
     <div>
-      <div className="relative mx-auto box-border w-full max-w-lg overflow-hidden">
+      <div className="max-w-lg relative mx-auto box-border w-full overflow-hidden">
         <div
-          className="box-border flex gap-2 transition-transform duration-300"
+          className="gap-2 box-border flex transition-transform duration-300"
           style={{
             transform: `translateX(calc(-${currentIndex * 80}% - ${currentIndex * 10}px  + 2px + 10%))`, // Tailwind cannot handle dynamic transform values
           }}
@@ -49,26 +49,26 @@ const Carousel = ({ items }) => {
         </div>
         <button
           aria-label="Previous Slide"
-          className="absolute top-1/2 left-2 flex h-7 w-7 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-blue-500 text-white hover:bg-blue-400"
+          className="left-2 h-7 w-7 absolute top-1/2 flex -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-primary-500 text-white hover:bg-primary-400"
           onClick={handlePrev}
         >
           &larr;
         </button>
         <button
           aria-label="Next Slide"
-          className="absolute top-1/2 right-2 flex h-7 w-7 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-blue-500 text-white hover:bg-blue-400"
+          className="right-2 h-7 w-7 absolute top-1/2 flex -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-primary-500 text-white hover:bg-primary-400"
           onClick={handleNext}
         >
           &rarr;
         </button>
       </div>
-      <div className="mx-auto mt-4 flex w-full max-w-lg justify-center space-x-2">
+      <div className="mt-4 max-w-lg space-x-2 mx-auto flex w-full justify-center">
         {items.map((_, index) => (
           <button
             key={`paginator-${index}`}
             className={cn(
               'h-2 w-2 cursor-pointer rounded-full',
-              index === currentIndex ? 'bg-blue-500' : 'bg-gray-400'
+              index === currentIndex ? 'bg-primary-500' : 'bg-gray-400'
             )}
             onClick={() => setCurrentIndex(index)}
           ></button>

--- a/src/components/carousel/Carousel.stories.jsx
+++ b/src/components/carousel/Carousel.stories.jsx
@@ -18,19 +18,19 @@ export const Default = {
     items: [
       <div
         key="slide-1"
-        className="flex h-64 items-center justify-center bg-blue-200 text-xl font-bold"
+        className="h-64 text-xl font-bold flex items-center justify-center bg-primary-200"
       >
         Slide 1
       </div>,
       <div
         key="slide-2"
-        className="flex h-64 items-center justify-center bg-green-200 text-xl font-bold"
+        className="h-64 bg-green-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 2
       </div>,
       <div
         key="slide-3"
-        className="flex h-64 items-center justify-center bg-red-200 text-xl font-bold"
+        className="h-64 bg-red-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 3
       </div>,

--- a/src/components/carousel/MultiCarousel.jsx
+++ b/src/components/carousel/MultiCarousel.jsx
@@ -45,7 +45,7 @@ const MultiCarousel = ({ items, slidesToShow = 1 }) => {
     <div>
       <div className="relative mx-auto w-full overflow-hidden">
         <div
-          className="mr-8 ml-8 flex gap-2 transition-transform duration-300"
+          className="mr-8 ml-8 gap-2 flex transition-transform duration-300"
           style={{
             transform: `translateX(calc(-${currentIndex * (100 / visibleSlides)}% - ${currentIndex * (10 / visibleSlides)}px))`,
           }}
@@ -72,25 +72,25 @@ const MultiCarousel = ({ items, slidesToShow = 1 }) => {
         </div>
         <button
           aria-label="Previous Slide"
-          className="absolute top-1/2 left-0 flex h-7 w-7 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-blue-500 text-white hover:bg-blue-400"
+          className="left-0 h-7 w-7 absolute top-1/2 flex -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-primary-500 text-white hover:bg-primary-400"
           onClick={handlePrev}
         >
           &larr;
         </button>
         <button
           aria-label="Next Slide"
-          className="absolute top-1/2 right-0 flex h-7 w-7 -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-blue-500 text-white hover:bg-blue-400"
+          className="right-0 h-7 w-7 absolute top-1/2 flex -translate-y-1/2 transform cursor-pointer items-center justify-center rounded-full bg-primary-500 text-white hover:bg-primary-400"
           onClick={handleNext}
         >
           &rarr;
         </button>
       </div>
-      <div className="mx-auto mt-4 flex w-full max-w-lg justify-center space-x-2">
+      <div className="mt-4 max-w-lg space-x-2 mx-auto flex w-full justify-center">
         {[...Array(totalPages)].map((_, pageIndex) => (
           <button
             key={`paginator-${pageIndex}`}
             className={`h-2 w-2 cursor-pointer rounded-full ${
-              pageIndex === currentPage ? 'bg-blue-500' : 'bg-gray-400'
+              pageIndex === currentPage ? 'bg-primary-500' : 'bg-gray-400'
             }`}
             onClick={() => goToPage(pageIndex)}
           ></button>

--- a/src/components/carousel/MultiCarousel.stories.jsx
+++ b/src/components/carousel/MultiCarousel.stories.jsx
@@ -25,37 +25,37 @@ export const Default = {
     items: [
       <div
         key="slide-1"
-        className="flex h-64 items-center justify-center bg-blue-200 text-xl font-bold"
+        className="h-64 text-xl font-bold flex items-center justify-center bg-primary-200"
       >
         Slide 1
       </div>,
       <div
         key="slide-2"
-        className="flex h-64 items-center justify-center bg-green-200 text-xl font-bold"
+        className="h-64 bg-green-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 2
       </div>,
       <div
         key="slide-3"
-        className="flex h-64 items-center justify-center bg-red-200 text-xl font-bold"
+        className="h-64 bg-red-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 3
       </div>,
       <div
         key="slide-4"
-        className="flex h-64 items-center justify-center bg-blue-200 text-xl font-bold"
+        className="h-64 text-xl font-bold flex items-center justify-center bg-primary-200"
       >
         Slide 4
       </div>,
       <div
         key="slide-5"
-        className="flex h-64 items-center justify-center bg-green-200 text-xl font-bold"
+        className="h-64 bg-green-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 5
       </div>,
       <div
         key="slide-6"
-        className="flex h-64 items-center justify-center bg-red-200 text-xl font-bold"
+        className="h-64 bg-red-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 6
       </div>,
@@ -69,37 +69,37 @@ export const MultipleSlidesVisible = {
     items: [
       <div
         key="slide-1"
-        className="flex h-64 items-center justify-center bg-blue-200 text-xl font-bold"
+        className="h-64 text-xl font-bold flex items-center justify-center bg-primary-200"
       >
         Slide 1
       </div>,
       <div
         key="slide-2"
-        className="flex h-64 items-center justify-center bg-green-200 text-xl font-bold"
+        className="h-64 bg-green-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 2
       </div>,
       <div
         key="slide-3"
-        className="flex h-64 items-center justify-center bg-red-200 text-xl font-bold"
+        className="h-64 bg-red-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 3
       </div>,
       <div
         key="slide-4"
-        className="flex h-64 items-center justify-center bg-blue-200 text-xl font-bold"
+        className="h-64 text-xl font-bold flex items-center justify-center bg-primary-200"
       >
         Slide 4
       </div>,
       <div
         key="slide-5"
-        className="flex h-64 items-center justify-center bg-green-200 text-xl font-bold"
+        className="h-64 bg-green-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 5
       </div>,
       <div
         key="slide-6"
-        className="flex h-64 items-center justify-center bg-red-200 text-xl font-bold"
+        className="h-64 bg-red-200 text-xl font-bold flex items-center justify-center"
       >
         Slide 6
       </div>,

--- a/src/components/feature-card.jsx
+++ b/src/components/feature-card.jsx
@@ -4,7 +4,7 @@ import { cn } from '../lib/utils'
 import Button from './button'
 
 const cardVariants = cva(
-  'flex w-full max-w-md flex-col items-start gap-4 rounded-2xl p-6 leading-[normal]',
+  'max-w-md gap-4 rounded-2xl p-6 flex w-full flex-col items-start leading-[normal]',
   {
     variants: {
       textColor: {
@@ -49,7 +49,7 @@ const FeatureCard = ({
         )}
       >
         <div>
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-700">
+          <div className="mb-4 h-12 w-12 rounded-lg flex items-center justify-center bg-primary-700">
             <FeatureIcon />
           </div>
           <Heading className="mb-4 text-lg font-bold">{heading}</Heading>

--- a/src/components/footer/footer-copyright-no-import.jsx
+++ b/src/components/footer/footer-copyright-no-import.jsx
@@ -17,7 +17,7 @@ const FooterCopyright = ({ footerElement, text, textColor }) => {
   const Footer = footerElement || 'footer'
 
   return (
-    <Footer className="mt-5 border-t border-slate-200 pt-5">
+    <Footer className="mt-5 pt-5 border-t border-gray-200">
       <p className={textVariants({ textColor })}>{text}</p>
     </Footer>
   )

--- a/src/components/footer/footer-copyright.jsx
+++ b/src/components/footer/footer-copyright.jsx
@@ -6,7 +6,7 @@ const FooterCopyright = ({ footerElement, text, textColor }) => {
   const Footer = footerElement || 'footer'
 
   return (
-    <Footer className="mt-5 border-t border-slate-200 pt-5">
+    <Footer className="mt-5 pt-5 border-t border-gray-200">
       <Copyright text={text} textColor={textColor} />
     </Footer>
   )

--- a/src/components/footer/footer-logo-top.jsx
+++ b/src/components/footer/footer-logo-top.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 export default function FooterLogoTop({ footerElement, logo, social }) {
   const Footer = footerElement || 'footer'
   return (
-    <Footer className="mt-5 grid w-full grid-cols-2 justify-between gap-4 border-t border-slate-200 px-8 py-3 pt-5 md:grid-cols-[1fr_1fr]">
-      <div className="my-1 max-h-8 items-center md:my-3">{logo}</div>
+    <Footer className="mt-5 gap-4 px-8 py-3 pt-5 md:grid-cols-[1fr_1fr] grid w-full grid-cols-2 justify-between border-t border-gray-200">
+      <div className="my-1 max-h-8 md:my-3 items-center">{logo}</div>
       {social && <div className="flex justify-end">{social}</div>}
     </Footer>
   )

--- a/src/components/footer/footer-menu.jsx
+++ b/src/components/footer/footer-menu.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { cn } from '../../lib/utils'
 
 const footerVariants = cva(
-  'mx-auto mt-auto w-full max-w-[85rem] border-t border-solid border-slate-200 px-4 py-10 sm:px-6 lg:px-8',
+  'px-4 py-10 sm:px-6 lg:px-8 mx-auto mt-auto w-full max-w-[85rem] border-t border-solid border-gray-200',
   {
     variants: {
       textColor: {
@@ -15,13 +15,13 @@ const footerVariants = cva(
   }
 )
 
-const gridVariants = cva('mb-10 grid gap-6', {
+const gridVariants = cva('mb-10 gap-6 grid', {
   variants: {
     columnLayout: {
       2: 'grid-cols-2',
-      3: 'grid-cols-2 lg:grid-cols-3',
-      4: 'grid-cols-2 md:grid-cols-3 lg:grid-cols-4',
-      5: 'grid-cols-2 md:grid-cols-4 lg:grid-cols-5',
+      3: 'lg:grid-cols-3 grid-cols-2',
+      4: 'md:grid-cols-3 lg:grid-cols-4 grid-cols-2',
+      5: 'md:grid-cols-4 lg:grid-cols-5 grid-cols-2',
     },
   },
   defaultVariants: {

--- a/src/components/footer/footer-minimal.jsx
+++ b/src/components/footer/footer-minimal.jsx
@@ -4,10 +4,10 @@ const FooterMinimal = ({ copyright, footerElement, social }) => {
   const Footer = footerElement || 'footer'
 
   return (
-    <Footer className="mt-5 border-t border-slate-200 pt-5">
+    <Footer className="mt-5 pt-5 border-t border-gray-200">
       <div className="sm:flex sm:items-center sm:justify-between">
         {copyright && (
-          <div className="flex flex-wrap items-center gap-3">{copyright}</div>
+          <div className="gap-3 flex flex-wrap items-center">{copyright}</div>
         )}
         {social}
       </div>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,8 +1,8 @@
 const Header = ({ logo, menu }) => {
   return (
-    <header className="grid w-full grid-cols-2 justify-center gap-4 border-b border-solid border-slate-200 bg-white px-8 py-3 leading-[normal] md:grid-cols-[1fr_auto_1fr]">
+    <header className="gap-4 px-8 py-3 md:grid-cols-[1fr_auto_1fr] grid w-full grid-cols-2 justify-center border-b border-solid border-gray-200 bg-white leading-[normal]">
       <div className="my-1 max-h-8 md:my-3">{logo}</div>
-      <div className="w-full md:content-center md:px-6 md:py-2">{menu}</div>
+      <div className="md:content-center md:px-6 md:py-2 w-full">{menu}</div>
     </header>
   )
 }

--- a/src/components/heading.jsx
+++ b/src/components/heading.jsx
@@ -15,13 +15,19 @@ const containerVariants = cva('dark flex w-full flex-col', {
 const preHeadingVariants = cva('mb-4 text-lg font-bold', {
   variants: {
     textColor: {
-      Dark: 'text-blue-700',
+      Dark: 'text-primary-dark',
       Light: 'text-primary-light',
+    },
+    headingSize: {
+      ExtraLarge: 'text-lg',
+      Large: 'text-base',
+      Medium: 'text-sm',
+      Small: 'text-xs',
     },
   },
 })
 
-const headingVariants = cva('leading-[normal] font-bold text-balance', {
+const headingVariants = cva('font-bold leading-[normal] text-balance', {
   variants: {
     textColor: {
       Dark: 'text-black',
@@ -49,7 +55,9 @@ const Heading = ({
   return (
     <div className={cn(containerVariants({ layout }), className)}>
       {preHeading && (
-        <div className={preHeadingVariants({ textColor })}>{preHeading}</div>
+        <div className={preHeadingVariants({ textColor, headingSize })}>
+          {preHeading}
+        </div>
       )}
       {heading && (
         <Heading className={headingVariants({ textColor, headingSize })}>

--- a/src/components/hero.stories.jsx
+++ b/src/components/hero.stories.jsx
@@ -1,36 +1,35 @@
-import Hero from "./hero";
+import Hero from './hero'
 
 export default {
-  title: "Sections/Hero",
+  title: 'Sections/Hero',
   component: Hero,
   argTypes: {
     layout: {
-      control: "select",
-      options: ["leftAligned", "centered"],
+      control: 'select',
+      options: ['leftAligned', 'centered'],
     },
   },
-};
+}
 
-const Template = (args) => <Hero {...args} />;
+const Template = (args) => <Hero {...args} />
 
-export const Default = Template.bind({});
+export const Default = Template.bind({})
 Default.args = {
-  layout: "leftAligned",
-  preHeading: "Mission",
-  heading: "This space deserves a hero.",
-  headingSize: "Large",
-  text: "This is a space to welcome visitors to the site. Grab their attention with copy that clearly states what the site is about.",
-  textColor: "Dark",
-  button1Label: "Get Started",
-  button1Link: "#get-started",
-  button1Style: "Solid",
-  button2Label: "Learn More",
-  button2Link: "#learn-more",
-  button2Style: "Outline",
-  image:
-    "/src/assets/images/placeholder.png?raw=true",
+  layout: 'leftAligned',
+  preHeading: 'Mission',
+  heading: 'This space deserves a hero.',
+  headingSize: 'Large',
+  text: 'This is a space to welcome visitors to the site. Grab their attention with copy that clearly states what the site is about.',
+  textColor: 'Dark',
+  button1Label: 'Get Started',
+  button1Link: '#get-started',
+  button1Style: 'Solid',
+  button2Label: 'Learn More',
+  button2Link: '#learn-more',
+  button2Style: 'Outline',
+  image: '/src/assets/images/placeholder.png?raw=true',
   backgroundImage:
-    "/src/assets/images/hero-background-placeholder-light.png?raw=true",
+    '/src/assets/images/hero-background-placeholder-light.png?raw=true',
   darkenImage: false,
-  backgroundColor: "bg-blue-600",
-};
+  backgroundColor: 'bg-primary-600',
+}

--- a/src/components/list/iconListItem.jsx
+++ b/src/components/list/iconListItem.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types'
 
 export default function IconListItem({ bulletImage, children }) {
   return (
-    <li className="mb-4 flex gap-x-3">
+    <li className="mb-4 gap-x-3 flex">
       {bulletImage ? (
-        <span className="mt-0.5 flex size-5 min-h-6 min-w-6 items-center justify-center rounded-full bg-blue-800 fill-white text-white">
+        <span className="mt-0.5 size-5 min-h-6 min-w-6 flex items-center justify-center rounded-full bg-primary-800 fill-white text-white">
           <img className="size-3.5" src={bulletImage} />
         </span>
       ) : null}

--- a/src/components/nav-menu/NavMenu.jsx
+++ b/src/components/nav-menu/NavMenu.jsx
@@ -26,8 +26,8 @@ const NavMenu = ({ children, variant = 'horizontal', className = '' }) => {
       className={cn(
         'nav-menu',
         variant === 'vertical'
-          ? 'flex flex-col space-y-2'
-          : 'flex flex-wrap space-x-4',
+          ? 'space-y-2 flex flex-col'
+          : 'space-x-4 flex flex-wrap',
         className
       )}
       role="navigation"
@@ -59,8 +59,8 @@ export const NavMenuItem = ({
         className={cn(
           isActive
             ? isVertical
-              ? 'border-l-2 border-blue-500'
-              : 'border-b-2 border-l-0 border-blue-500'
+              ? 'border-l-2 border-primary-500'
+              : 'border-b-2 border-l-0 border-primary-500'
             : '',
           className
         )}
@@ -76,12 +76,12 @@ export const NavMenuItem = ({
         )}
       </Link>
       {dropdownItems && isDropdownOpen && (
-        <div className="absolute left-0 mt-2 w-48 rounded-md bg-white shadow-lg">
-          <ul className="flex flex-col space-y-1">
+        <div className="left-0 mt-2 w-48 rounded-md shadow-lg absolute bg-white">
+          <ul className="space-y-1 flex flex-col">
             {dropdownItems.map((item) => (
               <li key={item.label} role="menuitem">
                 <a
-                  className="block rounded-md px-3 py-2 text-gray-800 hover:bg-gray-100"
+                  className="rounded-md px-3 py-2 block text-gray-800 hover:bg-gray-100"
                   href={item.href}
                   onClick={item.onClick}
                 >

--- a/src/components/navigation-menu.jsx
+++ b/src/components/navigation-menu.jsx
@@ -7,11 +7,11 @@ const NavigationMenu = ({ id, label, links }) => {
   const [open, setOpen] = useState(false)
   return (
     <>
-      <div className="flex justify-end md:hidden">
+      <div className="md:hidden flex justify-end">
         <button
           aria-expanded={open}
           aria-label="Toggle navigation"
-          className="relative flex size-9 items-center justify-center rounded-lg border border-gray-200 text-sm font-semibold text-gray-800 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none disabled:pointer-events-none"
+          className="size-9 rounded-lg text-sm font-semibold relative flex items-center justify-center border border-gray-200 text-gray-800 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none disabled:pointer-events-none"
           onClick={() => {
             setOpen(!open)
           }}
@@ -54,17 +54,17 @@ const NavigationMenu = ({ id, label, links }) => {
       <nav
         aria-label={label}
         className={cn(
-          'absolute left-0 w-screen border-b border-solid border-slate-200 bg-white px-10 py-6 md:static md:block md:w-full md:border-none md:px-8 md:py-0',
+          'left-0 px-10 py-6 md:static md:block md:w-full md:border-none md:px-8 md:py-0 absolute w-screen border-b border-solid border-gray-200 bg-white',
           open ? '' : 'hidden'
         )}
       >
-        <div className="max-h-[75vh] overflow-hidden overflow-y-auto">
-          <div className="flex flex-col gap-0.5 py-2 md:flex-row md:items-center md:justify-center md:gap-1 md:py-0">
+        <div className="p-2 max-h-[75vh] overflow-hidden overflow-y-auto">
+          <div className="gap-0.5 py-2 md:flex-row md:items-center md:justify-center md:gap-1 md:py-0 flex flex-col">
             {links.map(({ key, title, url }) => (
               <a
                 key={key}
                 aria-current="page"
-                className="flex items-center p-2 text-sm text-blue-600 focus:text-blue-600 focus:outline-none dark:text-blue-500 dark:focus:text-blue-500"
+                className="p-1 text-sm focus-visible:rounded-lg flex items-center text-primary-600 hover:text-primary-800 hover:underline hover:underline-offset-2 focus:text-primary-800 focus-visible:border-transparent focus-visible:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 active:text-primary-900"
                 href={url}
               >
                 {title}

--- a/src/components/page.stories.jsx
+++ b/src/components/page.stories.jsx
@@ -124,7 +124,7 @@ export const HomePage = {
     <Page {...args}>
       <Header logo={logo} menu={newMenuNotResponsive} />
       <Hero
-        backgroundColor="bg-blue-600"
+        backgroundColor="bg-primary-600"
         backgroundImage="/src/assets/images/hero-background-placeholder-dark.png?raw=true"
         button1Label="Get started"
         button1Link="#get-started"
@@ -209,7 +209,7 @@ export const HomePage = {
         />
       </CardContainer>
       <TwoColumnTextImage
-        className="mt-16 bg-slate-50 p-24"
+        className="mt-16 p-24 bg-gray-50"
         heading="Who we are."
         headingElement="h2"
         headingSize="Large"
@@ -242,7 +242,7 @@ export const HomePage = {
         <LogoCard image="/src/assets/images/logo.svg" />
         <LogoCard image="/src/assets/images/logo.svg" />
       </CardContainer>
-      <div className="mb-24 flex flex-wrap items-center justify-center gap-8">
+      <div className="mb-24 gap-8 flex flex-wrap items-center justify-center">
         <Text
           className="my-0"
           text="Over 2500 companies use us to better their business."

--- a/src/components/people/person.jsx
+++ b/src/components/people/person.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { cn } from '../../lib/utils'
 
 const cardVariants = cva(
-  'flex w-full max-w-md flex-col items-center gap-4 rounded-2xl pb-6 leading-[normal]',
+  'max-w-md gap-4 rounded-2xl pb-6 flex w-full flex-col items-center leading-[normal]',
   {
     variants: {
       layout: {
@@ -28,10 +28,10 @@ const headingVariants = cva('font-bold sm:text-base lg:text-lg', {
   },
 })
 
-const titleVariants = cva('text-xs text-blue-700 sm:text-sm lg:text-base', {
+const titleVariants = cva('text-xs sm:text-sm lg:text-base', {
   variants: {
     textColor: {
-      Dark: 'text-blue-700',
+      Dark: 'text-primary-dark',
       Light: 'text-primary-light',
     },
   },
@@ -75,7 +75,7 @@ function Person({
         <img
           alt={avatarAltText}
           className={cn(
-            'h-auto rounded-xl sm:w-48 lg:w-60',
+            'rounded-xl sm:w-48 lg:w-60 h-auto',
             imageClasses,
             layout === 'center' && 'mx-auto'
           )}
@@ -83,7 +83,7 @@ function Person({
         />
       )}
       {(name || title) && (
-        <div className={cn('mt-2 flex flex-col gap-1 sm:mt-4', textClasses)}>
+        <div className={cn('mt-2 gap-1 sm:mt-4 flex flex-col', textClasses)}>
           {name && (
             <Heading
               className={cn(headingVariants({ textColor: headingColor }))}

--- a/src/components/progressCard.jsx
+++ b/src/components/progressCard.jsx
@@ -6,17 +6,17 @@ const ProgressCard = ({
   footer = null,
 }) => {
   const statusBadge = {
-    'Not Started': 'bg-drupal-gray-mildest text-drupal-gray-darker',
-    'In Progress': 'bg-drupal-purple text-drupal-navy',
-    Completed: 'bg-green-200 text-drupal-green',
+    'Not Started': 'bg-gray-200 text-black',
+    'In Progress': 'bg-purple-200 text-black',
+    Completed: 'bg-green-200 text-black',
   }
   return (
-    <div className="w-full max-w-md rounded-lg bg-drupal-blue text-white shadow-sm transition-all duration-300 hover:shadow-lg">
-      <div className="flex flex-col space-y-1 p-6">
+    <div className="max-w-md rounded-lg shadow-sm hover:shadow-lg w-full bg-drupal-blue text-white transition-all duration-300">
+      <div className="space-y-1 p-6 flex flex-col">
         <div className="flex w-full items-start justify-between">
           <div className="space-y-2">
             <span
-              className={`${statusBadge[status]} inline-flex items-center rounded-full border-transparent px-2 py-0.5 text-xs font-medium`}
+              className={`${statusBadge[status]} px-2 py-0.5 text-xs font-medium inline-flex items-center rounded-full border-transparent`}
             >
               {status}
             </span>
@@ -24,7 +24,7 @@ const ProgressCard = ({
           </div>
           <a
             aria-label="Open"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-drupal-gray-mildest text-sm font-medium whitespace-nowrap text-drupal-dark-navy transition-colors hover:bg-drupal-gray-milder"
+            className="h-8 w-8 rounded-md text-sm font-medium inline-flex items-center justify-center bg-gray-100 whitespace-nowrap text-black transition-colors hover:bg-gray-300"
             href={link}
             rel="noopener noreferrer"
             target="_blank"
@@ -43,20 +43,20 @@ const ProgressCard = ({
       <div className="p-6 pt-0">
         <div className="space-y-4">
           <div className="space-y-2">
-            <div className="flex justify-between text-sm text-drupal-gray-mildest">
+            <div className="text-sm flex justify-between">
               <span>Progress</span>
               <span>{progress}%</span>
             </div>
             <div
               aria-valuemax="100"
               aria-valuemin="0"
-              className="relative h-2 w-full overflow-hidden rounded-full bg-drupal-light-blue"
+              className="h-2 relative w-full overflow-hidden rounded-full bg-primary-100"
               data-max="100"
               data-state="indeterminate"
               role="progressbar"
             >
               <div
-                className="h-full w-full flex-1 border-r-3 border-drupal-red bg-drupal-yellow transition-all"
+                className="border-red-600 bg-yellow-400 h-full w-full flex-1 border-r-3 transition-all"
                 data-max="100"
                 data-state="indeterminate"
                 style={{ transform: `translateX(-${100 - progress}%)` }}
@@ -69,9 +69,7 @@ const ProgressCard = ({
         </div>
       </div>
       {footer && (
-        <footer className="flex items-center p-6 pt-0 text-sm text-drupal-gray-mildest">
-          {footer}
-        </footer>
+        <footer className="p-6 pt-0 text-sm flex items-center">{footer}</footer>
       )}
     </div>
   )

--- a/src/components/testimonial/testimonial.jsx
+++ b/src/components/testimonial/testimonial.jsx
@@ -2,13 +2,13 @@ import { cva } from 'class-variance-authority'
 
 import { cn } from '../../lib/utils'
 
-const cardVariants = cva('flex flex-col gap-2 leading-[normal]', {
+const cardVariants = cva('gap-2 flex flex-col leading-[normal]', {
   variants: {
     layout: {
-      'Left aligned': 'items-start border-l-2 border-l-gray-200 pl-3 text-left',
+      'Left aligned': 'pl-3 items-start border-l-2 border-l-gray-200 text-left',
       'Center aligned':
-        'items-center border-l-2 border-l-gray-200 pl-3 text-center',
-      'Right aligned': 'items-end border-r-2 border-r-gray-200 pr-3 text-right',
+        'pl-3 items-center border-l-2 border-l-gray-200 text-center',
+      'Right aligned': 'pr-3 items-end border-r-2 border-r-gray-200 text-right',
     },
     textColor: {
       Dark: '',
@@ -48,7 +48,7 @@ const roleVariants = cva('text-sm', {
       Small: 'text-xs',
     },
     textColor: {
-      Dark: 'text-drupal-gray-default',
+      Dark: 'text-gray-700',
       Light: 'text-gray-300',
     },
   },
@@ -88,7 +88,7 @@ export default function Testimonial({
             <p>{text}</p>
           </blockquote>
         )}
-        <div className="flex items-center gap-4">
+        <div className="gap-4 flex items-center">
           {avatar && (
             <img
               alt={avatarAltText}
@@ -96,7 +96,7 @@ export default function Testimonial({
               src={avatar}
             />
           )}
-          <div className="flex flex-col gap-1">
+          <div className="gap-1 flex flex-col">
             {name && <p className={nameVariants({ textSize })}>{name}</p>}
             {(role || organization) && (
               <p

--- a/src/components/text.jsx
+++ b/src/components/text.jsx
@@ -5,7 +5,7 @@ import { cn } from '../lib/utils'
 const textVariants = cva('my-8', {
   variants: {
     textColor: {
-      Dark: 'text-slate-950',
+      Dark: 'text-black',
       Light: 'text-white',
     },
     textSize: {

--- a/src/global.css
+++ b/src/global.css
@@ -1,24 +1,5 @@
 @theme {
-  --color-drupal-blue: #009cde;
-  --color-drupal-dark-blue: #006aa9;
-  --color-drupal-navy: #12285f;
-  --color-drupal-dark-navy: #091942;
-  --color-drupal-light-blue: #ccedf9;
-  --color-drupal-black: #000;
-  --color-drupal-white: #fff;
-  --color-drupal-purple: #ccbaf4;
-  --color-drupal-yellow: #ffc423;
-  --color-drupal-red: #f46351;
-  --color-drupal-dark-red: #c63c00;
-  --color-drupal-green: #397618;
-  --color-drupal-gray-darkest: #1f2420;
-  --color-drupal-gray-darker: #323946;
-  --color-drupal-gray-dark: #4f5661;
-  --color-drupal-gray-default: #6d7583;
-  --color-drupal-gray-mild: #a2acbe;
-  --color-drupal-gray-milder: #cfd4dd;
-  --color-drupal-gray-mildest: #f8f9fc;
-  --color-drupal-gray-disabled: #e7ebf3;
+  --color-drupal-blue: #009cde; /* only used in drupal progress card - can be deleted and substituted with primary blue? */
 
   --color-primary-100: var(--color-blue-100);
   --color-primary-200: var(--color-blue-200);
@@ -30,10 +11,22 @@
   --color-primary-800: var(--color-blue-800);
   --color-primary-900: var(--color-blue-900);
 
-  --color-primary: var(--color-blue-600);
+  /* use for light and dark blue text */
+  --color-primary-dark: var(--color-blue-700);
   --color-primary-light: var(--color-slate-400);
-}
 
-html {
-  @apply text-slate-950;
+  --color-gray-50: var(--color-slate-50);
+  --color-gray-100: var(--color-slate-100);
+  --color-gray-200: var(--color-slate-200); /* layout border color */
+  --color-gray-300: var(--color-slate-300);
+  --color-gray-400: var(--color-slate-400);
+  --color-gray-500: var(--color-slate-500);
+  --color-gray-600: var(--color-slate-600);
+  --color-gray-700: var(--color-slate-700);
+  --color-gray-800: var(--color-slate-800);
+  --color-gray-900: var(--color-slate-900);
+
+  /* use for light and dark default text */
+  --color-white: #ffffff;
+  --color-black: var(--color-slate-950);
 }


### PR DESCRIPTION
Normalize colors so that colors referenced are from `global.css`

All dark and light default text should use white/black colors.
All layout border colors uses border-gray-200. Note: This doesn't include actions just things like header/footer/etc.

All blue colors should use `-primary-n`.
`primary-dark` and `primary-light` reserved for "blue" dark/light text.

All gray colors should use `-gray-n`. These point to slate. 
All neutral, slate and other gray colors use gray variables.

Remove all drupal colors except for the one drupal blue. Could possibly switch this to primary variable but leaving for now.

Remove dark theme usages for now since it hasn't been tested out to work.
Copy/paste some of the link colors around. Will continue to tweak further in later work.
