### PR TITLE
close menu item

### DIFF
--- a/src/components/nav-menu/NavMenu.jsx
+++ b/src/components/nav-menu/NavMenu.jsx
@@ -4,6 +4,21 @@ import PropTypes from 'prop-types'
 import { cn } from '../../lib/utils'
 import { Link } from '../button/button'
 
+const useClickOutside = (ref, callback) => {
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        callback()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [ref, callback])
+}
+
 const NavMenu = ({
   backgroundColor = '#ffffff',
   children,
@@ -22,18 +37,11 @@ const NavMenu = ({
     }
   }
 
-  const handleClickOutside = useCallback(
-    (event) => {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(event.target) &&
-        isOpen
-      ) {
-        setIsOpen(false)
-      }
-    },
-    [isOpen]
-  )
+  useClickOutside(menuRef, () => {
+    if (isOpen) {
+      setIsOpen(false)
+    }
+  })
 
   const handleResize = useCallback(() => {
     clearTimeout(timeoutRef.current)
@@ -43,16 +51,6 @@ const NavMenu = ({
       }
     }, 100)
   }, [isOpen])
-
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside)
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [isOpen, handleClickOutside])
 
   useEffect(() => {
     window.addEventListener('resize', handleResize)
@@ -116,6 +114,7 @@ export const NavMenuItem = ({
   isVertical = false,
   onClick,
 }) => {
+  const menuItemRef = useRef(null)
   const [isDropdownOpen, setDropdownOpen] = useState(false)
 
   const handleDropdownToggle = (e) => {
@@ -123,13 +122,28 @@ export const NavMenuItem = ({
     setDropdownOpen(!isDropdownOpen)
   }
 
+  function handleKeyDown(event) {
+    if (event.key === 'Escape') {
+      setDropdownOpen(false)
+    }
+  }
+
+  useClickOutside(menuItemRef, () => {
+    if (isDropdownOpen) {
+      setDropdownOpen(false)
+    }
+  })
+
   return (
     <div
+      ref={menuItemRef}
       className={cn('relative', 'bg-[var(--color-bg)]')}
+      onKeyDown={handleKeyDown}
       role={dropdownItems ? 'menu' : undefined}
       style={{
         '--color-bg': backgroundColor,
       }}
+      tabIndex={-1}
     >
       <Link
         className={cn(


### PR DESCRIPTION
Yesterday, I made the NavMenu responsive with the ability to use escape and click outside to close.
Refining further to update NavMenu item to re-use the escape and click outside logic.

<img width="968" alt="image" src="https://github.com/user-attachments/assets/4c8bbaee-a239-4e23-aad2-4a40863c209e" />

<img width="957" alt="image" src="https://github.com/user-attachments/assets/b57b68f3-7a16-4625-8d8f-0a76e8fff1ce" />

<img width="691" alt="image" src="https://github.com/user-attachments/assets/6d0c4e22-75e2-4e75-aa0a-d735a9298528" />

<img width="686" alt="image" src="https://github.com/user-attachments/assets/26b2ac25-8134-4043-889a-8baecd3f12a9" />

