### PR TITLE
fix(components:search-results): add working pagination

### DIFF
--- a/examples/components/search_results/index.jsx
+++ b/examples/components/search_results/index.jsx
@@ -5,7 +5,6 @@ import useSWR from "swr";
 
 const searchParams = new URLSearchParams(window.location.search);
 const q = searchParams.get("q") || "";
-
 const client = new JsonApiClient();
 
 function getOffsetFromLink(link) {
@@ -20,10 +19,6 @@ function getOffsetFromLink(link) {
 }
 
 export default function List() {
-  // Pagination can't be cleanly done currently due to how Canvas sets up
-  // @drupal-api-client/json-api-client with Jsona as the serializer by default.
-  // @see https://www.drupal.org/project/api_client/issues/3426518
-  const links = {};
   const [pageOffset, setPageOffset] = useState(0);
 
   const { data, error, isLoading } = useSWR(
@@ -39,7 +34,14 @@ export default function List() {
           .getQueryString(),
       },
     ],
-    ([type, options]) => client.getCollection(type, options),
+    async ([type, options]) => {
+      const json = await client.getCollection(type, options);
+
+      return {
+        results: Array.isArray(json) ? json : [],
+        links: json.getLinks() || {},
+      };
+    },
   );
 
   const handlePage = (link) => {
@@ -52,13 +54,16 @@ export default function List() {
   if (error) return "An error has occurred.";
   if (isLoading) return "Loading...";
 
+  const results = data?.results || [];
+  const links = data?.links || {};
+
   return (
     <div>
       <h2 className="text-2xl font-bold">Search results</h2>
       <ul className="mt-2 space-y-3">
-        {data.map((item, index) => (
+        {results.map((item) => (
           <li
-            key={index}
+            key={item?.id || item?.path?.alias || item?.title}
             className="mb-1 border-b border-[#E5E7EB] py-3 font-semibold"
           >
             <h3 className="text-[#2563EB]">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "drupal-canvas": "^0.1.2",
+        "drupal-canvas": "^0.2.0",
         "drupal-jsonapi-params": "^3.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -80,16 +80,16 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
-      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -400,24 +400,25 @@
       }
     },
     "node_modules/@drupal-api-client/json-api-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@drupal-api-client/json-api-client/-/json-api-client-1.3.0.tgz",
-      "integrity": "sha512-BjIw0r2NZeVEGcHTPVhWPjIJVzYFBP9Ngm3Wr6i5wP8IXIQmsXDxF8XSjsUCrKdDwuIr3MTi6KqHnH9QD5i9PA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@drupal-api-client/json-api-client/-/json-api-client-1.4.0.tgz",
+      "integrity": "sha512-YxyAGPp/+UDjtiVdE4/stb0O3bSAzjpwdVKRLFTVPUNEjtuTpK+oUxZ6qMbJu77eYcwCfWyDKcZua3/2T5Gmpw==",
       "license": "MIT",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.1.0",
         "@drupal-api-client/api-client": "^1.3.0",
         "@drupal-api-client/decoupled-router-client": "1.1.1",
-        "@drupal-api-client/utils": "0.3.0",
+        "@drupal-api-client/utils": "0.4.0",
         "@smithy/util-hex-encoding": "^2.0.0"
       }
     },
     "node_modules/@drupal-api-client/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@drupal-api-client/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-6YksA4+fVLrurN0pu1DqkN+mm6pOixhFtBAvuXQTBGbRqtLrmE+TnQpAhWMkLa0xSVq2gcLmqivZtTtewpbqVw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@drupal-api-client/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-W7vP+ezUwn949ZegYbvIt6ggqsmxURsVPuD4Ux7w3YTrj4l82QhgDbnTiyvARksuKy4loZJD/RmED3Ff2V3AuQ==",
       "license": "MIT",
       "dependencies": {
+        "jsona": "^1.11.0",
         "nanostores": "^0.10.2"
       }
     },
@@ -1638,9 +1639,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.10.0.tgz",
-      "integrity": "sha512-K9mY7V/f3Ul+/Gz4LJANZ3vJ/yiBIwCyxe0sPT4vNJK63Srvd+Yk1IzP0t+nE7XFSpIGtzR71yljtnqpUTYFlQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3624,14 +3625,13 @@
       }
     },
     "node_modules/drupal-canvas": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/drupal-canvas/-/drupal-canvas-0.1.2.tgz",
-      "integrity": "sha512-4eeh65L7VdyScSZ+bbJwGTt2vfolsGCDU4n51IydEEHL02rIN00dH13yUmGUG7TuOmkSXoTs8D0egavab/HnOg==",
-      "license": "GPL-2.0-or-later",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/drupal-canvas/-/drupal-canvas-0.2.0.tgz",
+      "integrity": "sha512-GRkRfic+s9eQuq8xwmxAy6oDNyvPQSbNQXHy38dODqbUwVvSn8EZNZP2Pz1Ck+lQ6Yo11RuUnwLzB3usvmuDWw==",
+      "license": "MIT",
       "dependencies": {
-        "@drupal-api-client/json-api-client": "^1.3.0",
+        "@drupal-api-client/json-api-client": "^1.4.0",
         "clsx": "^2.1.1",
-        "jsona": "^1.12.1",
         "next-image-standalone": "^0.1.3",
         "tailwind-merge": "^3.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "drupal-canvas": "^0.1.2",
+    "drupal-canvas": "^0.2.0",
     "drupal-jsonapi-params": "^3.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
This fix in Drupal Canvas now allows us to fix pagination in the `search-results` component: [#3570305: Make links and meta available by default in data returned by the preconfigured JsonApiClient](https://www.drupal.org/project/canvas/issues/3570305).