### PR TITLE
Instruct AI agent to not add fallback values for props

### DIFF
--- a/.agents/skills/canvas-component-metadata/SKILL.md
+++ b/.agents/skills/canvas-component-metadata/SKILL.md
@@ -30,6 +30,10 @@ Every prop definition must include a `title` for the UI label. The `examples`
 array is required for required props and recommended for all others. Only the
 first example value is used by Drupal Canvas.
 
+If a prop is listed in `required`, do not add a fallback/default value for that
+prop in the React component signature. Required Canvas props should be provided
+by metadata/editor input rather than silent JSX defaults.
+
 ```yaml
 props:
   properties:
@@ -38,6 +42,14 @@ props:
       type: string
       examples:
         - Enter a heading...
+```
+
+```jsx
+// Correct: required prop has no fallback default
+const Hero = ({ heading }) => <h1>{heading}</h1>;
+
+// Wrong: required prop fallback masks missing required data
+const Hero = ({ heading = "Default heading" }) => <h1>{heading}</h1>;
 ```
 
 **Prop IDs must be camelCase versions of their titles.**


### PR DESCRIPTION
**Motivation**
When using agents to create components they tend to add fallback values to all props. This leads to confusing behavior when editing content in Canvas.

**Proposed changes**
Add an agent skill that instructs the agent to not add fallback values to props.
