### PR TITLE
fix(components:grid_container): prevent card overflow on tablet

### DIFF
--- a/examples/components/grid_container/index.jsx
+++ b/examples/components/grid_container/index.jsx
@@ -30,7 +30,7 @@ const gridVariants = cva("grid w-full", {
 
 const GridContainer = ({ layout, gap, className, content, ...props }) => {
   return (
-    <div className="m-auto mx-6 w-full max-w-[1360px]">
+    <div className="mx-auto w-full max-w-[1360px] px-6">
       <div
         className={cn(gridVariants({ layout, gap, className }), className)}
         {...props}


### PR DESCRIPTION
## Summary

- Fixes cards being clipped or hidden outside the viewport in Drupal Canvas tablet mode
- Root cause: `w-full` + `mx-6` on `GridContainer`'s centering wrapper made the element `parent-width + 48px` wide, overflowing by 24px on the right and clipping the 3rd card column
- Fix: replace `mx-6` (external margin → overflow) with `px-6` (internal padding → no overflow), keeping `w-full` intact for correct flex child sizing

## Test plan

- [ ] Open the **Card Container** story at 768px viewport width (tablet breakpoint)
- [ ] Confirm all 3 cards in `33-33-33` layout are fully visible with no horizontal clipping
- [ ] View **Four Column Layout** story (`25-25-25-25`) and verify all 4 cards render correctly at tablet
- [ ] Open the **Grid Container** stories and confirm gutters still render correctly across all layout variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)