### PR TITLE
feat: add page cloning workflow, browser automation, and skill enhancements

### DIFF
--- a/.agents/skills/canvas-component-metadata/SKILL.md
+++ b/.agents/skills/canvas-component-metadata/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: canvas-component-metadata
 description:
-  Define valid component.yml metadata for Canvas components, including props,
-  slots, enums, and defensive prop handling patterns. Use when (1) Creating a
-  new component, (2) Adding or modifying props, (3) Troubleshooting "not a valid
-  choice" or prop type errors, (4) Mapping enums to CVA variants, (5) Guarding
-  against null/undefined props at runtime.
+  Define component.yml metadata and handle props defensively at runtime. Use
+  when creating components, adding props/slots, troubleshooting prop errors, or
+  guarding against null props.
 ---
 
 ## File structure
@@ -13,27 +11,30 @@ description:
 Every `component.yml` must include these top-level keys:
 
 ```yaml
-name: Component Name # Human-readable display name
-machineName: component-name # Machine name in kebab-case
-status: true # Whether the component is enabled
-required: [] # Array of required prop names
+name: Component Name
+machineName: component-name
+status: true
+required: []
 props:
   properties:
     # ... prop definitions
-slots: [] # Use [] only when there are no slots; otherwise use an object map
+slots: [] # [] when no slots; otherwise an object map
 ```
 
 ## Props
 
-### Requirements
+### Rules
 
-Every prop definition must include a `title` for the UI label. The `examples`
-array is required for required props and recommended for all others. Only the
-first example value is used by Drupal Canvas.
-
-If a prop is listed in `required`, do not add a fallback/default value for that
-prop in the React component signature. Required Canvas props should be provided
-by metadata/editor input rather than silent JSX defaults.
+- Every prop needs a `title`. The `examples` array is required for required
+  props, recommended otherwise. Only the first example value is used by Canvas.
+- **Prop IDs must be camelCase of their title.** `buttonText` for "Button Text",
+  `backgroundColor` for "Background Color".
+- **Never include `className` in component.yml.** It is a composition prop for
+  developers, not a Canvas editor control.
+- Only include Canvas-editable props. Implementation-only React props stay in
+  JSX only.
+- If a prop is in `required`, do NOT add a fallback default in the JSX component
+  signature. Required props must come from Canvas metadata/editor input.
 
 ```yaml
 props:
@@ -46,208 +47,26 @@ props:
 ```
 
 ```jsx
-// Correct: required prop has no fallback default
+// Correct: required prop has no fallback
 const Hero = ({ heading }) => <h1>{heading}</h1>;
 
-// Wrong: required prop fallback masks missing required data
+// Wrong: fallback masks missing required data
 const Hero = ({ heading = "Default heading" }) => <h1>{heading}</h1>;
 ```
 
-**Prop IDs must be camelCase versions of their titles.**
-
-The prop ID (the key under `properties`) must be the camelCase conversion of the
-`title` value.
-
-Only include user-facing, Canvas-editable props in `component.yml`.
-Implementation-only React props must stay in JSX and must not be added to
-metadata.
-
-**Never include `className` in `component.yml`.** Treat it as a composition prop
-for developers, not a Canvas editor control.
-
-```yaml
-# Correct
-props:
-  properties:
-    buttonText:           # camelCase of "Button Text"
-      title: Button Text
-      type: string
-    backgroundColor:      # camelCase of "Background Color"
-      title: Background Color
-      type: string
-    isVisible:            # camelCase of "Is Visible"
-      title: Is Visible
-      type: boolean
-
-# Wrong
-props:
-  properties:
-    btn_text:             # should be "buttonText" for title "Button Text"
-      title: Button Text
-    bgColor:              # should be "backgroundColor" for title "Background Color"
-      title: Background Color
-```
-
-### Prop types
-
-#### Text
-
-Basic text input. Stored as a string value.
-
-```yaml
-type: string
-examples:
-  - Hello, world!
-```
-
-#### Formatted text
-
-Rich text content with HTML formatting support, displayed in a block context.
-
-```yaml
-type: string
-contentMediaType: text/html
-x-formatting-context: block
-examples:
-  - <p>This is <strong>formatted</strong> text with HTML.</p>
-```
-
-#### Link
-
-URL or URI reference for links to internal or external resources.
-
-```yaml
-type: string
-format: uri-reference
-examples:
-  - /about/contact
-```
-
-**Note:** The format can be either `uri` (accepts only absolute URLs) or
-`uri-reference` (accepts both absolute and relative URLs).
-
-**IMPORTANT: Use proper path examples for URL props.** Do not use `#` as an
-example value for `uri-reference` props—it can cause validation failures during
-upload. Always use realistic path-like examples:
-
-```yaml
-# Correct
-examples:
-  - /resources
-  - /about/team
-  - https://example.com/page
-
-# Wrong
-examples:
-  - "#"
-  - ""
-```
-
-#### Image
-
-Reference to an image object with metadata like alt text, dimensions, and file
-URL. Only the file URL is required to exist, all other metadata is always
-optional.
-
-```yaml
-type: object
-$ref: json-schema-definitions://canvas.module/image
-examples:
-  - src: >-
-      https://images.unsplash.com/photo-1484959014842-cd1d967a39cf?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80
-    alt: Woman playing the violin
-    width: 1770
-    height: 1180
-```
-
-#### Video
-
-Reference to a video object with metadata like dimensions and file URL. Only the
-file URL is required to exist, all other metadata is always optional.
-
-```yaml
-type: object
-$ref: json-schema-definitions://canvas.module/video
-examples:
-  - src: https://media.istockphoto.com/id/1340051874/video/aerial-top-down-view-of-a-container-cargo-ship.mp4?s=mp4-640x640-is&k=20&c=5qPpYI7TOJiOYzKq9V2myBvUno6Fq2XM3ITPGFE8Cd8=
-    poster: https://example.com/600x400.png
-```
-
-#### Boolean
-
-True or false value.
-
-```yaml
-type: boolean
-examples:
-  - false
-```
-
-#### Integer
-
-Whole number value without decimal places.
-
-```yaml
-type: integer
-examples:
-  - 42
-```
-
-#### Number
-
-Numeric value that can include decimal places.
-
-```yaml
-type: number
-examples:
-  - 3.14
-```
-
-#### List: text
-
-A predefined list of text options that the user can select from.
-
-```yaml
-type: string
-enum:
-  - option1
-  - option2
-  - option3
-meta:enum:
-  option1: Option 1
-  option2: Option 2
-  option3: Option 3
-examples:
-  - option1
-```
-
-#### List: integer
-
-A predefined list of integer options that the user can select from.
-
-```yaml
-type: integer
-enum:
-  - 1
-  - 2
-  - 3
-meta:enum:
-  1: Option 1
-  2: Option 2
-  3: Option 3
-examples:
-  - 1
-```
+For prop type definitions and YAML examples (text, formatted text, link, image,
+video, boolean, integer, number, list:text, list:integer), see
+[references/prop-types.md](references/prop-types.md).
 
 ## Enums
 
-Enum values must use lowercase, machine-friendly identifiers. Use `meta:enum` to
-provide human-readable display labels for the UI.
-
-**Note:** Enum values cannot contain dots.
+- Values must be **lowercase, machine-friendly identifiers** (e.g.
+  `left_aligned`).
+- **No dots in enum values.**
+- Use `meta:enum` for human-readable UI labels.
+- `examples` must use the enum value, not the display label.
 
 ```yaml
-# Correct
 enum:
   - left_aligned
   - center_aligned
@@ -256,199 +75,25 @@ meta:enum:
   center_aligned: Center aligned
 examples:
   - left_aligned
-
-# Wrong
-enum:
-  - Left aligned
-  - Center aligned
 ```
 
-The `examples` value must be the enum value, not the display label.
-
-### Enum values must match JSX component variants
-
-When using class-variance-authority (CVA) or similar libraries in the JSX
-component, the variant keys must exactly match the enum values defined in
-`component.yml`.
+### CVA variants must match enum values exactly
 
 ```jsx
-// component.yml defines: enum: [left_aligned, center_aligned]
-// CVA variants must match:
 const variants = cva("base-classes", {
   variants: {
     layout: {
-      left_aligned: "text-left", // matches enum value
-      center_aligned: "text-center", // matches enum value
+      left_aligned: "text-left",
+      center_aligned: "text-center",
     },
   },
 });
 ```
 
-## Slots
-
-Slots allow other components to be embedded within a component. In React, each
-slot is received as a named prop that matches the slot key.
-
-This section is the slot schema source of truth. Other skills should reference
-these rules instead of redefining slot schema details.
-
-Before creating slots, confirm with the user unless the use case is clearly
-compositional (for example, rich nested content, or repeatable embedded
-components). For simple text-like values, prefer a prop.
-
-**Important:** Do not map Canvas slots to the `children` prop by default. If the
-slot key is `content`, consume it as `content` in JSX.
-
-Using a slot key named `children` is technically possible, but it is not
-recommended because slot naming often flows into user-facing Canvas labels.
-Prefer explicit slot keys such as `content`, `media`, or `actions`.
-
-`slots` must be either:
-
-1. An object map keyed by slot name (`content`, `sidebar`, etc.)
-2. `[]` when the component has no slots
-
-```yaml
-slots:
-  content:
-    title: Content
-  buttons:
-    title: Buttons
-```
-
-In the JSX component, slots are destructured as named props and rendered
-directly:
+**Always provide `defaultVariants`** so the component doesn't break when an enum
+prop is undefined:
 
 ```jsx
-const Section = ({ width, content }) => {
-  return <div className={sectionVariants({ width })}>{content}</div>;
-};
-```
-
-```jsx
-// Wrong when the slot key is `content`: this does not consume the named slot.
-const Section = ({ children }) => {
-  return <div>{children}</div>;
-};
-```
-
-Use `slots: []` only when the component has no slots:
-
-```yaml
-slots: []
-```
-
-Do not use arrays of slot objects:
-
-```yaml
-# Wrong
-slots:
-  - name: content
-    title: Content
-```
-
-### Slot minimum sizing
-
-Empty slots in the Canvas Editor are invisible without minimum dimensions,
-making it impossible to drag content into them. Add minimum sizing to slot
-containers:
-
-```jsx
-// Wrong — empty slot has zero height, can't drop content in editor
-const Section = ({ content }) => <div>{content}</div>;
-
-// Correct — minimum size keeps empty slots interactive
-const Section = ({ content }) => (
-  <div className="min-h-8 min-w-32">{content}</div>
-);
-```
-
-## Defensive prop handling
-
-Canvas components receive props from the CMS. Optional props can be `null`,
-`undefined`, or partially populated. Guard against these at runtime to prevent
-component crashes.
-
-### Null guards for each prop type
-
-**Image props:**
-
-```jsx
-// Wrong — crashes when image is null/undefined
-<img src={image.src} alt={image.alt} />;
-
-// Correct — guard with optional chaining
-{
-  image?.src && <img src={image.src} alt={image.alt || ""} />;
-}
-```
-
-**Formatted text props:**
-
-```jsx
-// Wrong — FormattedText with null value throws error
-<FormattedText text={body} />;
-
-// Correct — guard before rendering
-{
-  body && <FormattedText text={body} />;
-}
-```
-
-**Video props:**
-
-```jsx
-// Wrong — crashes if video is undefined
-<video src={video.src} poster={video.poster} />;
-
-// Correct — guard before rendering
-{
-  video?.src && <video src={video.src} poster={video.poster} controls />;
-}
-```
-
-**Link props:**
-
-```jsx
-// Wrong — crashes if link is null
-<a href={link}>Click here</a>;
-
-// Correct — guard and handle both string and object forms
-{
-  link && <a href={typeof link === "string" ? link : link.uri}>{linkText}</a>;
-}
-```
-
-### String-or-object dual format
-
-Some props may arrive as either a plain string or an object depending on how
-content was authored. Handle both forms defensively:
-
-```jsx
-// Link can be "/about" (string) or { uri: "/about", title: "About" } (object)
-const href = typeof link === "string" ? link : link?.uri;
-
-// Image can be a URL string or { src: "...", alt: "..." } object
-const imgSrc = typeof image === "string" ? image : image?.src;
-```
-
-### CVA defaultVariants
-
-When using CVA for enum-driven styling, always provide `defaultVariants` so the
-component doesn't break when an enum prop is undefined:
-
-```jsx
-// Wrong — no fallback if color is undefined
-const styles = cva("base-class", {
-  variants: {
-    color: {
-      primary: "bg-primary-600 text-white",
-      secondary: "bg-gray-100 text-gray-900",
-    },
-  },
-});
-
-// Correct — defaultVariants provides a fallback
 const styles = cva("base-class", {
   variants: {
     color: {
@@ -462,8 +107,53 @@ const styles = cva("base-class", {
 });
 ```
 
-### General rule
+## Slots
 
-Any prop not listed in `required` in component.yml can be null or undefined at
-runtime. Use `?.` and `&&` guards for all optional props before accessing nested
-properties or rendering components that expect non-null values.
+This section is the slot schema source of truth. Other skills should reference
+these rules.
+
+- `slots` must be either an **object map** keyed by slot name, or **`[]`** when
+  the component has no slots.
+- Do not use arrays of slot objects.
+- Do not map slots to `children`. If the slot key is `content`, consume it as
+  `content` in JSX.
+- Prefer explicit slot keys (`content`, `media`, `actions`) over `children`.
+- Confirm slot usage with the user unless the use case is clearly compositional.
+
+```yaml
+slots:
+  content:
+    title: Content
+  buttons:
+    title: Buttons
+```
+
+```jsx
+const Section = ({ width, content }) => (
+  <div className={sectionVariants({ width })}>{content}</div>
+);
+```
+
+### Slot minimum sizing
+
+Empty slots in Canvas Editor are invisible without minimum dimensions, making
+drag-and-drop impossible. Always add minimum sizing:
+
+```jsx
+// Wrong -- zero height, can't drop content
+const Section = ({ content }) => <div>{content}</div>;
+
+// Correct -- minimum size keeps empty slots interactive
+const Section = ({ content }) => (
+  <div className="min-h-8 min-w-32">{content}</div>
+);
+```
+
+## Defensive prop handling
+
+Any prop not in `required` can be null/undefined at runtime. Use `?.` and `&&`
+guards for all optional props before accessing nested properties or rendering.
+
+For null guard patterns per prop type and string-or-object dual format handling,
+see [references/defensive-patterns.md](references/defensive-patterns.md). Load
+this reference when implementing optional props in index.jsx.

--- a/.agents/skills/canvas-component-metadata/SKILL.md
+++ b/.agents/skills/canvas-component-metadata/SKILL.md
@@ -2,9 +2,10 @@
 name: canvas-component-metadata
 description:
   Define valid component.yml metadata for Canvas components, including props,
-  slots, and enums. Use when (1) Creating a new component, (2) Adding or
-  modifying props, (3) Troubleshooting "not a valid choice" or prop type errors,
-  (4) Mapping enums to CVA variants.
+  slots, enums, and defensive prop handling patterns. Use when (1) Creating a
+  new component, (2) Adding or modifying props, (3) Troubleshooting "not a valid
+  choice" or prop type errors, (4) Mapping enums to CVA variants, (5) Guarding
+  against null/undefined props at runtime.
 ---
 
 ## File structure
@@ -345,3 +346,124 @@ slots:
   - name: content
     title: Content
 ```
+
+### Slot minimum sizing
+
+Empty slots in the Canvas Editor are invisible without minimum dimensions,
+making it impossible to drag content into them. Add minimum sizing to slot
+containers:
+
+```jsx
+// Wrong — empty slot has zero height, can't drop content in editor
+const Section = ({ content }) => <div>{content}</div>;
+
+// Correct — minimum size keeps empty slots interactive
+const Section = ({ content }) => (
+  <div className="min-h-8 min-w-32">{content}</div>
+);
+```
+
+## Defensive prop handling
+
+Canvas components receive props from the CMS. Optional props can be `null`,
+`undefined`, or partially populated. Guard against these at runtime to prevent
+component crashes.
+
+### Null guards for each prop type
+
+**Image props:**
+
+```jsx
+// Wrong — crashes when image is null/undefined
+<img src={image.src} alt={image.alt} />;
+
+// Correct — guard with optional chaining
+{
+  image?.src && <img src={image.src} alt={image.alt || ""} />;
+}
+```
+
+**Formatted text props:**
+
+```jsx
+// Wrong — FormattedText with null value throws error
+<FormattedText text={body} />;
+
+// Correct — guard before rendering
+{
+  body && <FormattedText text={body} />;
+}
+```
+
+**Video props:**
+
+```jsx
+// Wrong — crashes if video is undefined
+<video src={video.src} poster={video.poster} />;
+
+// Correct — guard before rendering
+{
+  video?.src && <video src={video.src} poster={video.poster} controls />;
+}
+```
+
+**Link props:**
+
+```jsx
+// Wrong — crashes if link is null
+<a href={link}>Click here</a>;
+
+// Correct — guard and handle both string and object forms
+{
+  link && <a href={typeof link === "string" ? link : link.uri}>{linkText}</a>;
+}
+```
+
+### String-or-object dual format
+
+Some props may arrive as either a plain string or an object depending on how
+content was authored. Handle both forms defensively:
+
+```jsx
+// Link can be "/about" (string) or { uri: "/about", title: "About" } (object)
+const href = typeof link === "string" ? link : link?.uri;
+
+// Image can be a URL string or { src: "...", alt: "..." } object
+const imgSrc = typeof image === "string" ? image : image?.src;
+```
+
+### CVA defaultVariants
+
+When using CVA for enum-driven styling, always provide `defaultVariants` so the
+component doesn't break when an enum prop is undefined:
+
+```jsx
+// Wrong — no fallback if color is undefined
+const styles = cva("base-class", {
+  variants: {
+    color: {
+      primary: "bg-primary-600 text-white",
+      secondary: "bg-gray-100 text-gray-900",
+    },
+  },
+});
+
+// Correct — defaultVariants provides a fallback
+const styles = cva("base-class", {
+  variants: {
+    color: {
+      primary: "bg-primary-600 text-white",
+      secondary: "bg-gray-100 text-gray-900",
+    },
+  },
+  defaultVariants: {
+    color: "primary",
+  },
+});
+```
+
+### General rule
+
+Any prop not listed in `required` in component.yml can be null or undefined at
+runtime. Use `?.` and `&&` guards for all optional props before accessing nested
+properties or rendering components that expect non-null values.

--- a/.agents/skills/canvas-component-metadata/references/defensive-patterns.md
+++ b/.agents/skills/canvas-component-metadata/references/defensive-patterns.md
@@ -1,0 +1,103 @@
+# Defensive Prop Handling
+
+Any prop not listed in `required` in component.yml can be null or undefined at
+runtime. Guard all optional props before accessing nested properties or
+rendering components that expect non-null values.
+
+## Null guards by prop type
+
+### Image
+
+```jsx
+// Wrong -- crashes when image is null/undefined
+<img src={image.src} alt={image.alt} />;
+
+// Correct
+{
+  image?.src && <img src={image.src} alt={image.alt || ""} />;
+}
+```
+
+### Formatted text
+
+```jsx
+// Wrong -- FormattedText with null value throws
+<FormattedText text={body} />;
+
+// Correct
+{
+  body && <FormattedText text={body} />;
+}
+```
+
+### Video
+
+```jsx
+// Wrong -- crashes if video is undefined
+<video src={video.src} poster={video.poster} />;
+
+// Correct
+{
+  video?.src && <video src={video.src} poster={video.poster} controls />;
+}
+```
+
+### Link
+
+```jsx
+// Wrong -- crashes if link is null
+<a href={link}>Click here</a>;
+
+// Correct -- handle both string and object forms
+{
+  link && <a href={typeof link === "string" ? link : link.uri}>{linkText}</a>;
+}
+```
+
+## String-or-object dual format
+
+Some props arrive as either a plain string or an object depending on how content
+was authored. Handle both:
+
+```jsx
+// Link: "/about" (string) or { uri: "/about", title: "About" } (object)
+const href = typeof link === "string" ? link : link?.uri;
+
+// Image: URL string or { src: "...", alt: "..." } object
+const imgSrc = typeof image === "string" ? image : image?.src;
+```
+
+## CVA defaultVariants
+
+Always provide `defaultVariants` so enum-driven styling doesn't break when a
+prop is undefined:
+
+```jsx
+// Wrong -- no fallback if color is undefined
+const styles = cva("base-class", {
+  variants: {
+    color: {
+      primary: "bg-primary-600 text-white",
+      secondary: "bg-gray-100 text-gray-900",
+    },
+  },
+});
+
+// Correct
+const styles = cva("base-class", {
+  variants: {
+    color: {
+      primary: "bg-primary-600 text-white",
+      secondary: "bg-gray-100 text-gray-900",
+    },
+  },
+  defaultVariants: {
+    color: "primary",
+  },
+});
+```
+
+## General rule
+
+Use `?.` for optional chaining and `&&` for conditional rendering on all
+optional props.

--- a/.agents/skills/canvas-component-metadata/references/prop-types.md
+++ b/.agents/skills/canvas-component-metadata/references/prop-types.md
@@ -1,0 +1,144 @@
+# Prop Type Definitions
+
+YAML examples for each prop type supported in `component.yml`.
+
+## Text
+
+```yaml
+type: string
+examples:
+  - Hello, world!
+```
+
+## Formatted text
+
+Rich text with HTML, displayed in a block context.
+
+```yaml
+type: string
+contentMediaType: text/html
+x-formatting-context: block
+examples:
+  - <p>This is <strong>formatted</strong> text with HTML.</p>
+```
+
+## Link
+
+`uri` accepts only absolute URLs. `uri-reference` accepts both absolute and
+relative.
+
+```yaml
+type: string
+format: uri-reference
+examples:
+  - /about/contact
+```
+
+**Do not use `#` as an example value** for `uri-reference` props -- it causes
+validation failures during upload. Use realistic paths:
+
+```yaml
+# Correct
+examples:
+  - /resources
+  - /about/team
+  - https://example.com/page
+
+# Wrong
+examples:
+  - "#"
+  - ""
+```
+
+## Image
+
+Reference to an image object. Only `src` is required; all other metadata is
+optional.
+
+```yaml
+type: object
+$ref: json-schema-definitions://canvas.module/image
+examples:
+  - src: >-
+      https://images.unsplash.com/photo-1484959014842-cd1d967a39cf?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80
+    alt: Woman playing the violin
+    width: 1770
+    height: 1180
+```
+
+## Video
+
+Reference to a video object. Only `src` is required; all other metadata is
+optional.
+
+```yaml
+type: object
+$ref: json-schema-definitions://canvas.module/video
+examples:
+  - src: https://media.istockphoto.com/id/1340051874/video/aerial-top-down-view-of-a-container-cargo-ship.mp4?s=mp4-640x640-is&k=20&c=5qPpYI7TOJiOYzKq9V2myBvUno6Fq2XM3ITPGFE8Cd8=
+    poster: https://example.com/600x400.png
+```
+
+## Boolean
+
+```yaml
+type: boolean
+examples:
+  - false
+```
+
+## Integer
+
+Whole number, no decimals.
+
+```yaml
+type: integer
+examples:
+  - 42
+```
+
+## Number
+
+Supports decimal places.
+
+```yaml
+type: number
+examples:
+  - 3.14
+```
+
+## List: text
+
+Predefined text options. Pair with `meta:enum` for UI labels.
+
+```yaml
+type: string
+enum:
+  - option1
+  - option2
+  - option3
+meta:enum:
+  option1: Option 1
+  option2: Option 2
+  option3: Option 3
+examples:
+  - option1
+```
+
+## List: integer
+
+Predefined integer options.
+
+```yaml
+type: integer
+enum:
+  - 1
+  - 2
+  - 3
+meta:enum:
+  1: Option 1
+  2: Option 2
+  3: Option 3
+examples:
+  - 1
+```

--- a/.agents/skills/canvas-component-upload/SKILL.md
+++ b/.agents/skills/canvas-component-upload/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: canvas-component-upload
 description:
-  Upload validated components to Drupal Canvas and recover from common upload
-  failures. Use after component work is complete and validated. Handles upload
-  failures including dependency-related issues that require retry.
+  Upload validated components to Drupal Canvas with a pre-upload validation
+  pipeline and post-upload verification. Use after component work is complete.
+  Covers preflight checks (lint, validate, SSR test), upload execution, failure
+  recovery, and verification in the Canvas Code Editor.
 ---
 
 ## Upload to Canvas
@@ -29,11 +30,79 @@ Before running any upload command:
      <https://www.npmjs.com/package/@drupal-canvas/cli>
 5. Continue only after the user confirms setup is complete.
 
+## Pre-upload validation
+
+Run these checks in order before uploading. Each catches different issues and
+saves time compared to debugging failures after upload.
+
+### 1. Fix formatting and linting
+
+```bash
+npm run code:fix
+```
+
+Auto-fixes Prettier formatting, ESLint issues, and import ordering. If issues
+remain after the fix, resolve them manually before continuing.
+
+### 2. Validate component metadata
+
+```bash
+npx canvas validate
+```
+
+Validates all `component.yml` files against the Canvas schema. Common failures:
+
+- Missing `title` on props
+- Missing `examples` on required props
+- `machineName` doesn't match folder name
+- Invalid prop type
+- `className` included in metadata (composition-only, not a declared prop)
+
+### 3. Test server-side rendering
+
+```bash
+npx canvas ssr-test
+```
+
+Renders each component in a Node.js environment (no browser). Catches:
+
+- Runtime errors (undefined variables, null access on optional props)
+- Missing imports
+- Browser-only APIs used without guards (`window`, `document`)
+- Components that crash with default/example prop values
+
+If SSR fails, the component will crash in Canvas — fix before uploading.
+
+### 4. Verify in Storybook
+
+Before uploading, open Storybook and verify components render correctly with
+realistic content. Check:
+
+- Components render actual content, not empty states or placeholders
+- Images load correctly (not broken references)
+- Slots accept and render children
+- All theme variants produce distinct visual output
+- Desktop and mobile viewports both work
+
+### Preflight convenience script
+
+Optionally add a combined preflight script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "canvas:preflight": "npm run code:fix && npx canvas validate && npx canvas ssr-test"
+  }
+}
+```
+
+Then run `npm run canvas:preflight` before every upload.
+
 ## Run upload
 
-When component work is complete and validated, ask the user if they would like
-to upload the modified components to Canvas. Make sure to use the right package
-manager. For example, if using npm, run the following command:
+When pre-upload validation passes, ask the user if they would like to upload the
+modified components to Canvas. Make sure to use the right package manager. For
+example, if using npm, run the following command:
 
 ```bash
 npx canvas upload -c component1,component2,component3 -y
@@ -89,3 +158,21 @@ Example scenario:
 
 If uploads continue to fail after multiple retries, check that all dependency
 components are included in the upload command.
+
+## Post-upload verification
+
+After a successful upload, verify each component in the Canvas Code Editor:
+
+```
+<CANVAS_SITE_URL>/canvas/code-editor/component/<machine-name>
+```
+
+Check that:
+
+- The component appears in the component list
+- The props panel shows the correct fields from `component.yml`
+- The preview renders without errors
+- The source code tab shows the uploaded version
+
+If a component doesn't appear after upload, verify that the `machineName` in
+`component.yml` matches the component folder name exactly.

--- a/.agents/skills/canvas-component-upload/SKILL.md
+++ b/.agents/skills/canvas-component-upload/SKILL.md
@@ -2,9 +2,8 @@
 name: canvas-component-upload
 description:
   Upload Canvas components with pre-upload validation and post-upload
-  verification. Use when components are ready to deploy. Covers preflight checks
-  (lint, validate, SSR test), Storybook visual verification, upload execution,
-  dependency-order failure recovery, and Canvas Code Editor verification.
+  verification. Use when components are ready to deploy, when upload fails with
+  dependency errors, or when verifying components are live in Canvas.
 compatibility:
   Requires .env in project root with CANVAS_SITE_URL, CANVAS_CLIENT_ID,
   CANVAS_CLIENT_SECRET.

--- a/.agents/skills/canvas-component-upload/SKILL.md
+++ b/.agents/skills/canvas-component-upload/SKILL.md
@@ -1,39 +1,37 @@
 ---
 name: canvas-component-upload
 description:
-  Upload validated components to Drupal Canvas with a pre-upload validation
-  pipeline and post-upload verification. Use after component work is complete.
-  Covers preflight checks (lint, validate, SSR test), upload execution, failure
-  recovery, and verification in the Canvas Code Editor.
+  Upload Canvas components with pre-upload validation and post-upload
+  verification. Use when components are ready to deploy. Covers preflight checks
+  (lint, validate, SSR test), Storybook visual verification, upload execution,
+  dependency-order failure recovery, and Canvas Code Editor verification.
+compatibility:
+  Requires .env in project root with CANVAS_SITE_URL, CANVAS_CLIENT_ID,
+  CANVAS_CLIENT_SECRET.
 ---
 
-## Upload to Canvas
+## Setup gate
 
-Before uploading, confirm the user has Drupal Canvas CLI installed and
-configured for their target site.
+Before running any upload command, verify `.env` exists in the project root with
+`CANVAS_SITE_URL`, `CANVAS_CLIENT_ID`, and `CANVAS_CLIENT_SECRET` set. If
+missing, stop and point the user to
+<https://git.drupalcode.org/project/canvas/-/tree/1.x/modules/canvas_oauth#2-setup>
+and <https://www.npmjs.com/package/@drupal-canvas/cli>. Continue only after the
+user confirms setup is complete.
 
-### Setup gate
+## Pre-upload validation pipeline
 
-Before running any upload command:
+Run these checks in order. Each catches different issues and saves time compared
+to debugging failures after upload.
 
-1. Check that a `.env` file exists in the project root.
-2. If `.env` exists, verify these values are set:
-   - `CANVAS_SITE_URL`
-   - `CANVAS_CLIENT_ID`
-   - `CANVAS_CLIENT_SECRET`
-3. If `.env` is missing, or any required value is missing, **stop** and ask the
-   user to complete setup first.
-4. **Do not guess setup steps**. Point the user to the official docs:
-   - Drupal Canvas OAuth module setup:
-     <https://git.drupalcode.org/project/canvas/-/tree/1.x/modules/canvas_oauth#2-setup>
-   - Drupal Canvas CLI package/docs:
-     <https://www.npmjs.com/package/@drupal-canvas/cli>
-5. Continue only after the user confirms setup is complete.
+### Preflight checklist
 
-## Pre-upload validation
-
-Run these checks in order before uploading. Each catches different issues and
-saves time compared to debugging failures after upload.
+- [ ] Run `npm run code:fix` (formatting + linting)
+- [ ] Run `npx canvas validate` (component.yml schema)
+- [ ] Run `npx canvas ssr-test` (server-side rendering)
+- [ ] Verify in Storybook (visual check)
+- [ ] Upload: `npx canvas upload -c <components> -y`
+- [ ] Verify in Canvas Code Editor
 
 ### 1. Fix formatting and linting
 
@@ -41,8 +39,8 @@ saves time compared to debugging failures after upload.
 npm run code:fix
 ```
 
-Auto-fixes Prettier formatting, ESLint issues, and import ordering. If issues
-remain after the fix, resolve them manually before continuing.
+Auto-fixes Prettier formatting, ESLint issues, and import ordering. Resolve any
+remaining issues manually before continuing.
 
 ### 2. Validate component metadata
 
@@ -64,29 +62,24 @@ Validates all `component.yml` files against the Canvas schema. Common failures:
 npx canvas ssr-test
 ```
 
-Renders each component in a Node.js environment (no browser). Catches:
-
-- Runtime errors (undefined variables, null access on optional props)
-- Missing imports
-- Browser-only APIs used without guards (`window`, `document`)
-- Components that crash with default/example prop values
-
-If SSR fails, the component will crash in Canvas — fix before uploading.
+Renders each component in Node.js (no browser). Catches runtime errors, missing
+imports, unguarded browser-only APIs (`window`, `document`), and components that
+crash with default/example prop values. If SSR fails, the component will crash
+in Canvas -- fix before uploading.
 
 ### 4. Verify in Storybook
 
-Before uploading, open Storybook and verify components render correctly with
-realistic content. Check:
+Open Storybook and confirm components render correctly with realistic content:
 
 - Components render actual content, not empty states or placeholders
-- Images load correctly (not broken references)
+- Images load (no broken references)
 - Slots accept and render children
 - All theme variants produce distinct visual output
 - Desktop and mobile viewports both work
 
 ### Preflight convenience script
 
-Optionally add a combined preflight script to `package.json`:
+Optionally add to `package.json`:
 
 ```json
 {
@@ -96,83 +89,50 @@ Optionally add a combined preflight script to `package.json`:
 }
 ```
 
-Then run `npm run canvas:preflight` before every upload.
-
 ## Run upload
 
-When pre-upload validation passes, ask the user if they would like to upload the
-modified components to Canvas. Make sure to use the right package manager. For
-example, if using npm, run the following command:
+When validation passes, ask the user to confirm, then upload:
 
 ```bash
 npx canvas upload -c component1,component2,component3 -y
 ```
 
-Replace `component1,component2,component3` with the actual component names that
-were created or modified (e.g., `canvas upload -c button,card,hero`).
+Replace component names with actual modified components (e.g.,
+`button,card,hero`).
 
 ## Handling upload failures
 
-Default behavior: **always retry failed uploads** unless the error is clearly a
-connection/setup failure.
+Default: **always retry** unless the error is clearly a connection/setup
+failure.
 
-Retry uploads when the failure indicates the Canvas app connection is already
-working (for example, dependency/order-related component errors). Do **not**
-retry connection/setup failures.
+### Connection/setup failures -- stop, do not retry
 
-### Connection/setup failures: Stop, do not retry
+If upload fails with auth, network, DNS, TLS, or timeout errors, stop and ask
+the user to verify `.env` values and OAuth/CLI setup. Point to the setup docs
+above. Retry only after the user confirms fixes.
 
-If upload fails with authentication, authorization, or network/connection
-errors, stop and ask the user to complete or verify setup first. This includes
-errors like invalid credentials, unauthorized/forbidden responses, DNS issues,
-connection refused, host unreachable, request timeout before reaching Canvas, or
-TLS/SSL handshake/certificate failures.
+### Dependency-order failures -- retry
 
-Point the user to the official setup docs:
-
-- Drupal Canvas OAuth module setup:
-  <https://git.drupalcode.org/project/canvas/-/tree/1.x/modules/canvas_oauth#2-setup>
-- Drupal Canvas CLI package/docs:
-  <https://www.npmjs.com/package/@drupal-canvas/cli>
-
-Ask them to verify and update `.env` values (`CANVAS_SITE_URL`,
-`CANVAS_CLIENT_ID`, `CANVAS_CLIENT_SECRET`) and OAuth/CLI setup, then retry the
-upload only after they confirm setup updates are complete.
-
-### Dependency-related failures
-
-When uploading multiple new components where one component depends on another
-(e.g., `hero` imports `heading`), the upload may fail with a message indicating
-that a component doesn't exist. This happens when a component that includes
-another gets uploaded before its dependency.
-
-**This is expected behavior.** Simply retry the upload command. On subsequent
-attempts, the dependencies that were successfully uploaded in the previous run
-will already exist, allowing the dependent components to upload successfully.
-
-Example scenario:
-
-1. First upload attempt: `hero` fails because `heading` doesn't exist yet, but
-   `heading` uploads successfully.
-2. Second upload attempt: `hero` now succeeds because `heading` exists.
-
-If uploads continue to fail after multiple retries, check that all dependency
-components are included in the upload command.
+When uploading multiple new components where one depends on another (e.g.,
+`hero` imports `heading`), the upload may fail because a dependency hasn't been
+uploaded yet. **This is expected.** Retry the same upload command -- previously
+uploaded dependencies will now exist. If uploads keep failing after 3 retries,
+check that all dependency components are included in the upload command.
 
 ## Post-upload verification
 
-After a successful upload, verify each component in the Canvas Code Editor:
+After successful upload, verify each component in the Canvas Code Editor:
 
 ```
 <CANVAS_SITE_URL>/canvas/code-editor/component/<machine-name>
 ```
 
-Check that:
+Confirm:
 
-- The component appears in the component list
-- The props panel shows the correct fields from `component.yml`
-- The preview renders without errors
-- The source code tab shows the uploaded version
+- Component appears in the component list
+- Props panel shows correct fields from `component.yml`
+- Preview renders without errors
+- Source code tab shows the uploaded version
 
-If a component doesn't appear after upload, verify that the `machineName` in
-`component.yml` matches the component folder name exactly.
+If a component doesn't appear, verify `machineName` in `component.yml` matches
+the folder name exactly.

--- a/.agents/skills/canvas-data-fetching/SKILL.md
+++ b/.agents/skills/canvas-data-fetching/SKILL.md
@@ -2,9 +2,12 @@
 name: canvas-data-fetching
 description:
   Fetch and render Drupal content in Canvas components with JSON:API and SWR
-  patterns. Use when building content lists, integrating with SWR, or querying
-  related entities. Covers JsonApiClient, DrupalJsonApiParams, relationship
-  handling, and filter patterns.
+  patterns. Also covers content write operations — creating pages, uploading
+  media, composing component trees, and managing content entities via JSON:API.
+  Use when building content lists, integrating with SWR, querying related
+  entities, or programmatically composing pages. Covers JsonApiClient,
+  DrupalJsonApiParams, relationship handling, filter patterns, CRUD operations,
+  page component structure, input format reference, and common pitfalls.
 ---
 
 # Data fetching
@@ -181,3 +184,204 @@ category, filter by author):
 
 This ensures filters stay in sync with the actual content in Drupal and new
 options appear automatically without code changes.
+
+## Content write operations
+
+The JSON:API supports creating, updating, and deleting content entities. These
+operations use standard JSON:API request formats with `fetch()`.
+
+**Prerequisites:** JSON:API must have write mode enabled. Drupal defaults to
+read-only. If write operations return HTTP 405, enable writes in Drupal admin or
+via drush (`drush config:set jsonapi.settings read_only false -y`).
+
+### Create an entity
+
+```js
+const response = await fetch(`${siteUrl}/${jsonapiPrefix}/node/page`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/vnd.api+json",
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+  body: JSON.stringify({
+    data: {
+      type: "node--page",
+      attributes: {
+        title: "My Page",
+        status: true,
+        path: { alias: "/my-page" },
+        components: [
+          /* component tree — see Page Component Structure below */
+        ],
+      },
+    },
+  }),
+});
+```
+
+### Update an entity
+
+```js
+await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
+  method: "PATCH",
+  headers: {
+    "Content-Type": "application/vnd.api+json",
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+  body: JSON.stringify({
+    data: {
+      type: "node--page",
+      id: uuid,
+      attributes: {
+        title: "Updated Title",
+      },
+    },
+  }),
+});
+```
+
+### Delete an entity
+
+```js
+await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
+  method: "DELETE",
+  headers: {
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+});
+```
+
+## Page component structure
+
+Pages in Canvas contain a `components` attribute — a flat array where nesting is
+encoded via `parent_uuid` and `slot` fields:
+
+```json
+{
+  "data": {
+    "type": "node--page",
+    "attributes": {
+      "title": "My Page",
+      "status": true,
+      "components": [
+        {
+          "uuid": "comp-001",
+          "component_id": "js.section",
+          "inputs": { "width": "Normal" },
+          "parent_uuid": null,
+          "slot": null
+        },
+        {
+          "uuid": "comp-002",
+          "component_id": "js.heading",
+          "inputs": { "text": "Welcome", "level": "h2" },
+          "parent_uuid": "comp-001",
+          "slot": "content"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Component fields
+
+| Field          | Description                                                              |
+| -------------- | ------------------------------------------------------------------------ |
+| `uuid`         | Unique identifier for this component instance. Generate before creation. |
+| `component_id` | Component type (e.g., `js.heading`, `js.card`)                           |
+| `inputs`       | Object containing prop values matching component.yml                     |
+| `parent_uuid`  | UUID of parent component (`null` for root-level)                         |
+| `slot`         | Slot name in parent (`null` for root-level, e.g., `"content"`)           |
+
+Root-level components have `parent_uuid: null` and `slot: null`. Child
+components reference their parent's UUID and the slot name they occupy.
+
+## Input format reference
+
+**Always read `component.yml` before composing inputs.** The prop type in
+`component.yml` determines how the value must be formatted in the JSON:API
+request body.
+
+| component.yml type                                | JSON input format          | Example                                                            |
+| ------------------------------------------------- | -------------------------- | ------------------------------------------------------------------ |
+| `type: string` (plain)                            | Plain string               | `"heading": "Hello"`                                               |
+| `type: string` with `contentMediaType: text/html` | Formatted text object      | `"text": {"value": "<p>Hello</p>", "format": "canvas_html_block"}` |
+| `type: string` with `format: uri-reference`       | Plain string (path or URL) | `"link": "/about"`                                                 |
+| `type: object` with `$ref: .../image`             | target_id object (string)  | `"image": {"target_id": "31"}`                                     |
+| `type: string` with `enum`                        | Exact enum value string    | `"layout": "left"`                                                 |
+| `type: boolean`                                   | Boolean                    | `"visible": true`                                                  |
+| `type: integer` / `type: number`                  | Number                     | `"count": 3`                                                       |
+
+## Media upload
+
+Images must be uploaded to the media library before referencing them in
+components. The workflow is:
+
+1. Upload the file binary to create a file entity
+2. Create a media entity referencing the file
+3. Use the media entity's internal ID as `target_id` in component inputs
+
+The `target_id` must be the **media entity's internal ID** (visible in the media
+entity's `resourceVersion` or self link), not the underlying file entity's
+`drupal_internal__target_id`.
+
+### Referencing images in components
+
+```json
+{
+  "component_id": "js.card",
+  "inputs": {
+    "heading": "My Card",
+    "image": { "target_id": "31" },
+    "text": { "value": "<p>Content</p>", "format": "canvas_html_block" }
+  }
+}
+```
+
+## Common pitfalls
+
+1. **`target_id` must be a string.** Image references use `"target_id": "31"`
+   (string), not `"target_id": 31` (integer). Using an integer may cause type
+   errors or silent failures.
+
+2. **Link props are plain strings, not objects.** Link/URL props
+   (`format: uri-reference`) must be plain strings like `"/about"`. Do NOT use
+   Drupal's link field format `{"uri": "/about", "options": []}` — that is for
+   Drupal entity reference fields, not Canvas component inputs.
+
+   ```json
+   // Correct
+   "link": "/services"
+
+   // Wrong — will cause errors
+   "link": { "uri": "/services", "options": [] }
+   ```
+
+3. **Formatted text needs the wrapper object.** Any prop with
+   `contentMediaType: text/html` in component.yml must use the formatted text
+   object. A plain string will cause rendering failures or empty output.
+
+   ```json
+   // Correct
+   "text": { "value": "<p>Content here</p>", "format": "canvas_html_block" }
+
+   // Wrong — plain string for an HTML field
+   "text": "Content here"
+   ```
+
+4. **Media entity ID vs file entity ID.** When uploading images, there are two
+   internal IDs. The file entity has `drupal_internal__target_id` in its
+   relationships. The media entity has a separate internal ID. Always use the
+   **media** entity's ID in component inputs — using the file ID causes
+   "image.src NULL value found" errors.
+
+5. **JSON:API read-only mode.** If all write operations return HTTP 405, the
+   JSON:API is configured for read-only. Enable write operations in Drupal admin
+   or via drush.
+
+6. **Omit `langcode` on create.** When creating entities, omit the `langcode`
+   field — the API may reject it with permission errors.

--- a/.agents/skills/canvas-data-fetching/SKILL.md
+++ b/.agents/skills/canvas-data-fetching/SKILL.md
@@ -1,47 +1,19 @@
 ---
 name: canvas-data-fetching
 description:
-  Fetch and render Drupal content in Canvas components with JSON:API and SWR
-  patterns. Also covers content write operations — creating pages, uploading
-  media, composing component trees, and managing content entities via JSON:API.
-  Use when building content lists, integrating with SWR, querying related
-  entities, or programmatically composing pages. Covers JsonApiClient,
-  DrupalJsonApiParams, relationship handling, filter patterns, CRUD operations,
-  page component structure, input format reference, and common pitfalls.
+  Fetch and manage Drupal content via JSON:API. Use when building content lists,
+  composing pages programmatically, uploading media, or querying entities with
+  SWR.
+compatibility:
+  Requires .env with CANVAS_SITE_URL, CANVAS_CLIENT_ID, CANVAS_CLIENT_SECRET
 ---
 
-# Data fetching
+# Data Fetching
 
-## Data fetching with SWR
+## Reading content with SWR + JSON:API
 
-Use [SWR](https://swr.vercel.app/) for all data fetching. It provides caching,
-revalidation, and a clean hook-based API.
-
-```jsx
-import useSWR from "swr";
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
-
-export default function Profile() {
-  const { data, error, isLoading } = useSWR(
-    "https://my-site.com/api/user",
-    fetcher,
-  );
-
-  if (error) return <div>Failed to load</div>;
-  if (isLoading) return <div>Loading...</div>;
-  return <div>Hello, {data.name}!</div>;
-}
-```
-
-## Fetching Drupal content with JSON:API
-
-To fetch content from Drupal (e.g., articles, events, or other content types),
-use the autoconfigured `JsonApiClient` from the `drupal-canvas` package combined
-with `DrupalJsonApiParams` for query building.
-
-**Important:** Do not mock JSON:API resources in Storybook stories. Components
-that fetch data will display their loading or empty states in Storybook.
+Use `JsonApiClient` from `drupal-canvas` with `DrupalJsonApiParams` for query
+building and SWR for caching/revalidation.
 
 ```jsx
 import { getNodePath, JsonApiClient } from "drupal-canvas";
@@ -74,34 +46,19 @@ const Articles = () => {
     </ul>
   );
 };
-
-export default Articles;
 ```
 
-### Including relationships with `addInclude`
+**Do not mock JSON:API resources in Storybook.** Components that fetch data will
+display their loading or empty states in Storybook.
 
-When you need related entities (e.g., images, taxonomy terms), use `addInclude`
-to fetch them in a single request.
+### Including relationships
 
-**Avoid circular references in JSON:API responses.** SWR uses deep equality
-checks to compare cached data, which fails with "too much recursion" errors when
-the response contains circular references.
-
-**Do not include self-referential fields.** Fields that reference the same
-entity type being queried (e.g., `field_related_articles` on an article query)
-create circular references: Article A references Article B, which references
-back to Article A. If you need related content of the same type, fetch it in a
-separate query.
-
-**Use `addFields` to limit the response.** Always specify only the fields you
-need. This improves performance and helps avoid circular reference issues:
+Use `addInclude` for related entities and `addFields` to limit the response:
 
 ```jsx
 const params = new DrupalJsonApiParams();
 params.addSort("created", "DESC");
 params.addInclude(["field_category", "field_image"]);
-
-// Limit fields for each entity type
 params.addFields("node--article", [
   "title",
   "created",
@@ -112,276 +69,79 @@ params.addFields("taxonomy_term--categories", ["name"]);
 params.addFields("file--file", ["uri", "url"]);
 ```
 
-## Creating content list components
+**Avoid circular references.** Do not include self-referential fields (e.g.,
+`field_related_articles` on an article query). SWR deep-equality checks fail
+with "too much recursion" on circular data. Fetch same-type related content in a
+separate query.
 
-When building a component that displays a list of content items (e.g., a news
-listing, event calendar, or resource library), follow this workflow:
+## Building content list components
 
 ### Setup gate
 
-Before any JSON:API discovery or content-type checks, verify local setup:
+Before any JSON:API discovery, verify connectivity:
 
-1. Check that a `.env` file exists in the project root.
-2. If `.env` exists, verify `CANVAS_SITE_URL` is set. Read
-   `CANVAS_JSONAPI_PREFIX` if present; otherwise, use `jsonapi`.
-3. Send an HTTP request to `{CANVAS_SITE_URL}/{CANVAS_JSONAPI_PREFIX}`. Success
-   means HTTP `200`.
-4. If the request is successful, continue with Drupal data fetching.
-5. If the request is unsuccessful (or required `.env` values are missing), ask
-   the user whether they want to:
-   - Configure Drupal connectivity now, or
-   - Continue with static content instead of Drupal fetching.
-6. If the user chooses to configure connectivity, provide `.env` instructions:
-   - `CANVAS_SITE_URL=<their Drupal site URL>`
-   - `CANVAS_JSONAPI_PREFIX=jsonapi` (optional; defaults to `jsonapi`) Then wait
-     for the user to confirm they updated `.env`, and test the request again.
-7. If the user chooses not to configure connectivity, proceed with static
-   content.
-8. Do not update Vite config (`vite.config.*`) to troubleshoot connectivity.
-   Connectivity issues must be resolved via correct `.env` values and Drupal
-   site availability, not build tooling changes.
+1. Check `.env` exists with `CANVAS_SITE_URL`. Read `CANVAS_JSONAPI_PREFIX` if
+   present; default to `jsonapi`.
+2. Send HTTP request to `{CANVAS_SITE_URL}/{CANVAS_JSONAPI_PREFIX}`. Success =
+   HTTP 200.
+3. If unsuccessful or values missing, ask the user whether to configure
+   connectivity now or proceed with static content.
+4. Do not modify Vite config to troubleshoot connectivity.
 
-### Step 1: Analyze the list structure
+### Workflow
 
-Examine the design to understand what data each list item needs:
-
-- What fields are displayed (title, date, image, category, etc.)?
-- How are items sorted (newest first, alphabetical, etc.)?
-- Are there filters or pagination?
-
-### Step 2: Identify or request the content type
-
-Before writing code, verify that an appropriate content type exists in Drupal:
-
-1. Check the JSON:API endpoint of your local Drupal site (configured via
-   `CANVAS_SITE_URL` and `CANVAS_JSONAPI_PREFIX` environment variables) to find
-   a content type that matches the required structure. Use a plain `fetch`
-   request for this check, after passing the Setup gate.
-
-2. If a matching content type exists, use it and note which fields are
-   available.
-
-3. If no matching content type exists, **stop and prompt the user** to create
-   one. Provide:
-   - A suggested content type name
-   - The required field structure based on the list design
-
-### Step 3: Build the component
-
-Create the content list component using JSON:API to fetch content. Only use
-fields that actually exist on the content type—do not assume fields exist
-without verifying.
+1. **Analyze the list structure** -- what fields, sort order, filters, and
+   pagination does the design require?
+2. **Identify or request the content type** -- verify via JSON:API that a
+   matching content type exists. If not, stop and prompt the user to create one
+   with a suggested name and field structure.
+3. **Build the component** -- only use fields verified to exist on the content
+   type.
 
 ### Handling filters
 
-If the list includes filters based on entity reference fields (e.g., filter by
-category, filter by author):
+Do not hardcode filter options. Fetch available options dynamically via JSON:API
+(e.g., all taxonomy terms in a vocabulary) so filters stay in sync with content.
 
-- **Do not hardcode filter options.** Filter options should be fetched
-  dynamically using JSON:API.
-- Fetch the available options for each filter (e.g., all taxonomy terms in a
-  vocabulary) and populate the filter UI from that data.
+## Write operations
 
-This ensures filters stay in sync with the actual content in Drupal and new
-options appear automatically without code changes.
-
-## Content write operations
-
-The JSON:API supports creating, updating, and deleting content entities. These
-operations use standard JSON:API request formats with `fetch()`.
-
-**Prerequisites:** JSON:API must have write mode enabled. Drupal defaults to
-read-only. If write operations return HTTP 405, enable writes in Drupal admin or
-via drush (`drush config:set jsonapi.settings read_only false -y`).
-
-### Create an entity
-
-```js
-const response = await fetch(`${siteUrl}/${jsonapiPrefix}/node/page`, {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/vnd.api+json",
-    Accept: "application/vnd.api+json",
-    Authorization: `Bearer ${token}`,
-  },
-  body: JSON.stringify({
-    data: {
-      type: "node--page",
-      attributes: {
-        title: "My Page",
-        status: true,
-        path: { alias: "/my-page" },
-        components: [
-          /* component tree — see Page Component Structure below */
-        ],
-      },
-    },
-  }),
-});
-```
-
-### Update an entity
-
-```js
-await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
-  method: "PATCH",
-  headers: {
-    "Content-Type": "application/vnd.api+json",
-    Accept: "application/vnd.api+json",
-    Authorization: `Bearer ${token}`,
-  },
-  body: JSON.stringify({
-    data: {
-      type: "node--page",
-      id: uuid,
-      attributes: {
-        title: "Updated Title",
-      },
-    },
-  }),
-});
-```
-
-### Delete an entity
-
-```js
-await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
-  method: "DELETE",
-  headers: {
-    Accept: "application/vnd.api+json",
-    Authorization: `Bearer ${token}`,
-  },
-});
-```
+When creating, updating, or deleting entities, or uploading media, read
+[references/crud-operations.md](references/crud-operations.md) for fetch()
+patterns and the media upload workflow.
 
 ## Page component structure
 
-Pages in Canvas contain a `components` attribute — a flat array where nesting is
-encoded via `parent_uuid` and `slot` fields:
-
-```json
-{
-  "data": {
-    "type": "node--page",
-    "attributes": {
-      "title": "My Page",
-      "status": true,
-      "components": [
-        {
-          "uuid": "comp-001",
-          "component_id": "js.section",
-          "inputs": { "width": "Normal" },
-          "parent_uuid": null,
-          "slot": null
-        },
-        {
-          "uuid": "comp-002",
-          "component_id": "js.heading",
-          "inputs": { "text": "Welcome", "level": "h2" },
-          "parent_uuid": "comp-001",
-          "slot": "content"
-        }
-      ]
-    }
-  }
-}
-```
-
-### Component fields
-
-| Field          | Description                                                              |
-| -------------- | ------------------------------------------------------------------------ |
-| `uuid`         | Unique identifier for this component instance. Generate before creation. |
-| `component_id` | Component type (e.g., `js.heading`, `js.card`)                           |
-| `inputs`       | Object containing prop values matching component.yml                     |
-| `parent_uuid`  | UUID of parent component (`null` for root-level)                         |
-| `slot`         | Slot name in parent (`null` for root-level, e.g., `"content"`)           |
-
-Root-level components have `parent_uuid: null` and `slot: null`. Child
-components reference their parent's UUID and the slot name they occupy.
+When composing page component trees (flat array with `parent_uuid`/`slot`
+nesting), read [references/page-structure.md](references/page-structure.md) for
+the JSON structure and field definitions.
 
 ## Input format reference
 
-**Always read `component.yml` before composing inputs.** The prop type in
-`component.yml` determines how the value must be formatted in the JSON:API
-request body.
-
-| component.yml type                                | JSON input format          | Example                                                            |
-| ------------------------------------------------- | -------------------------- | ------------------------------------------------------------------ |
-| `type: string` (plain)                            | Plain string               | `"heading": "Hello"`                                               |
-| `type: string` with `contentMediaType: text/html` | Formatted text object      | `"text": {"value": "<p>Hello</p>", "format": "canvas_html_block"}` |
-| `type: string` with `format: uri-reference`       | Plain string (path or URL) | `"link": "/about"`                                                 |
-| `type: object` with `$ref: .../image`             | target_id object (string)  | `"image": {"target_id": "31"}`                                     |
-| `type: string` with `enum`                        | Exact enum value string    | `"layout": "left"`                                                 |
-| `type: boolean`                                   | Boolean                    | `"visible": true`                                                  |
-| `type: integer` / `type: number`                  | Number                     | `"count": 3`                                                       |
-
-## Media upload
-
-Images must be uploaded to the media library before referencing them in
-components. The workflow is:
-
-1. Upload the file binary to create a file entity
-2. Create a media entity referencing the file
-3. Use the media entity's internal ID as `target_id` in component inputs
-
-The `target_id` must be the **media entity's internal ID** (visible in the media
-entity's `resourceVersion` or self link), not the underlying file entity's
-`drupal_internal__target_id`.
-
-### Referencing images in components
-
-```json
-{
-  "component_id": "js.card",
-  "inputs": {
-    "heading": "My Card",
-    "image": { "target_id": "31" },
-    "text": { "value": "<p>Content</p>", "format": "canvas_html_block" }
-  }
-}
-```
+When mapping `component.yml` prop types to JSON:API input values, read
+[references/input-formats.md](references/input-formats.md) for the
+type-to-format conversion table.
 
 ## Common pitfalls
 
 1. **`target_id` must be a string.** Image references use `"target_id": "31"`
-   (string), not `"target_id": 31` (integer). Using an integer may cause type
-   errors or silent failures.
+   (string), not `"target_id": 31` (integer). Integer causes type errors or
+   silent failures.
 
-2. **Link props are plain strings, not objects.** Link/URL props
-   (`format: uri-reference`) must be plain strings like `"/about"`. Do NOT use
-   Drupal's link field format `{"uri": "/about", "options": []}` — that is for
-   Drupal entity reference fields, not Canvas component inputs.
+2. **Link props are plain strings, not objects.** Props with
+   `format: uri-reference` must be plain strings like `"/about"`. Do NOT use
+   `{"uri": "/about", "options": []}`.
 
-   ```json
-   // Correct
-   "link": "/services"
+3. **Formatted text needs the wrapper object.** Props with
+   `contentMediaType: text/html` require
+   `{"value": "<p>...</p>", "format": "canvas_html_block"}`. A plain string
+   causes rendering failures.
 
-   // Wrong — will cause errors
-   "link": { "uri": "/services", "options": [] }
-   ```
+4. **Media entity ID vs file entity ID.** Always use the **media** entity's
+   internal ID in component inputs, not the file entity's
+   `drupal_internal__target_id`. Wrong ID causes "image.src NULL value found"
+   errors.
 
-3. **Formatted text needs the wrapper object.** Any prop with
-   `contentMediaType: text/html` in component.yml must use the formatted text
-   object. A plain string will cause rendering failures or empty output.
+5. **JSON:API read-only mode.** HTTP 405 on writes means read-only mode. Enable
+   via `drush config:set jsonapi.settings read_only false -y`.
 
-   ```json
-   // Correct
-   "text": { "value": "<p>Content here</p>", "format": "canvas_html_block" }
-
-   // Wrong — plain string for an HTML field
-   "text": "Content here"
-   ```
-
-4. **Media entity ID vs file entity ID.** When uploading images, there are two
-   internal IDs. The file entity has `drupal_internal__target_id` in its
-   relationships. The media entity has a separate internal ID. Always use the
-   **media** entity's ID in component inputs — using the file ID causes
-   "image.src NULL value found" errors.
-
-5. **JSON:API read-only mode.** If all write operations return HTTP 405, the
-   JSON:API is configured for read-only. Enable write operations in Drupal admin
-   or via drush.
-
-6. **Omit `langcode` on create.** When creating entities, omit the `langcode`
-   field — the API may reject it with permission errors.
+6. **Omit `langcode` on create.** The API may reject it with permission errors.

--- a/.agents/skills/canvas-data-fetching/references/crud-operations.md
+++ b/.agents/skills/canvas-data-fetching/references/crud-operations.md
@@ -1,0 +1,96 @@
+# CRUD Operations & Media Upload
+
+## Prerequisites
+
+JSON:API must have write mode enabled. Drupal defaults to read-only. If write
+operations return HTTP 405, enable writes in Drupal admin or via drush:
+
+```sh
+drush config:set jsonapi.settings read_only false -y
+```
+
+## Create an entity
+
+```js
+const response = await fetch(`${siteUrl}/${jsonapiPrefix}/node/page`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/vnd.api+json",
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+  body: JSON.stringify({
+    data: {
+      type: "node--page",
+      attributes: {
+        title: "My Page",
+        status: true,
+        path: { alias: "/my-page" },
+        components: [
+          /* component tree — see page-structure.md */
+        ],
+      },
+    },
+  }),
+});
+```
+
+## Update an entity
+
+```js
+await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
+  method: "PATCH",
+  headers: {
+    "Content-Type": "application/vnd.api+json",
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+  body: JSON.stringify({
+    data: {
+      type: "node--page",
+      id: uuid,
+      attributes: {
+        title: "Updated Title",
+      },
+    },
+  }),
+});
+```
+
+## Delete an entity
+
+```js
+await fetch(`${siteUrl}/${jsonapiPrefix}/node/page/${uuid}`, {
+  method: "DELETE",
+  headers: {
+    Accept: "application/vnd.api+json",
+    Authorization: `Bearer ${token}`,
+  },
+});
+```
+
+## Media upload
+
+Images must be uploaded to the media library before referencing them in
+components:
+
+1. Upload the file binary to create a file entity
+2. Create a media entity referencing the file
+3. Use the media entity's internal ID as `target_id` in component inputs
+
+The `target_id` must be the **media entity's internal ID** (visible in the media
+entity's `resourceVersion` or self link), not the underlying file entity's
+`drupal_internal__target_id`.
+
+### Referencing images in components
+
+```json
+{
+  "component_id": "js.card",
+  "inputs": {
+    "heading": "My Card",
+    "image": { "target_id": "31" },
+    "text": { "value": "<p>Content</p>", "format": "canvas_html_block" }
+  }
+}
+```

--- a/.agents/skills/canvas-data-fetching/references/input-formats.md
+++ b/.agents/skills/canvas-data-fetching/references/input-formats.md
@@ -1,0 +1,15 @@
+# Input Format Reference
+
+**Always read `component.yml` before composing inputs.** The prop type in
+`component.yml` determines how the value must be formatted in the JSON:API
+request body.
+
+| component.yml type                                | JSON input format          | Example                                                            |
+| ------------------------------------------------- | -------------------------- | ------------------------------------------------------------------ |
+| `type: string` (plain)                            | Plain string               | `"heading": "Hello"`                                               |
+| `type: string` with `contentMediaType: text/html` | Formatted text object      | `"text": {"value": "<p>Hello</p>", "format": "canvas_html_block"}` |
+| `type: string` with `format: uri-reference`       | Plain string (path or URL) | `"link": "/about"`                                                 |
+| `type: object` with `$ref: .../image`             | target_id object (string)  | `"image": {"target_id": "31"}`                                     |
+| `type: string` with `enum`                        | Exact enum value string    | `"layout": "left"`                                                 |
+| `type: boolean`                                   | Boolean                    | `"visible": true`                                                  |
+| `type: integer` / `type: number`                  | Number                     | `"count": 3`                                                       |

--- a/.agents/skills/canvas-data-fetching/references/page-structure.md
+++ b/.agents/skills/canvas-data-fetching/references/page-structure.md
@@ -1,0 +1,47 @@
+# Page Component Structure
+
+Pages in Canvas contain a `components` attribute — a flat array where nesting is
+encoded via `parent_uuid` and `slot` fields.
+
+## Example
+
+```json
+{
+  "data": {
+    "type": "node--page",
+    "attributes": {
+      "title": "My Page",
+      "status": true,
+      "components": [
+        {
+          "uuid": "comp-001",
+          "component_id": "js.section",
+          "inputs": { "width": "Normal" },
+          "parent_uuid": null,
+          "slot": null
+        },
+        {
+          "uuid": "comp-002",
+          "component_id": "js.heading",
+          "inputs": { "text": "Welcome", "level": "h2" },
+          "parent_uuid": "comp-001",
+          "slot": "content"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Component fields
+
+| Field          | Description                                                              |
+| -------------- | ------------------------------------------------------------------------ |
+| `uuid`         | Unique identifier for this component instance. Generate before creation. |
+| `component_id` | Component type (e.g., `js.heading`, `js.card`)                           |
+| `inputs`       | Object containing prop values matching component.yml                     |
+| `parent_uuid`  | UUID of parent component (`null` for root-level)                         |
+| `slot`         | Slot name in parent (`null` for root-level, e.g., `"content"`)           |
+
+Root-level components have `parent_uuid: null` and `slot: null`. Child
+components reference their parent's UUID and the slot name they occupy.

--- a/.agents/skills/nebula-clone-page/SKILL.md
+++ b/.agents/skills/nebula-clone-page/SKILL.md
@@ -1,27 +1,24 @@
 ---
 name: nebula-clone-page
 description:
-  Clone a web page or Figma design into Canvas components with full visual QA.
-  Orchestrates extraction, component auditing, building, visual comparison, and
-  page story composition. Accepts a site URL or Figma URL. Use when the user
-  wants to recreate a page, section, or design as Canvas components in
-  Storybook. This skill coordinates sub-agents with specialized skills — it does
-  not build components directly.
+  Clone a web page or Figma design into Canvas components. Use when the user
+  provides a URL or Figma link and wants to recreate it as Canvas components in
+  Storybook. Orchestrates extraction, building, visual QA, and page story
+  composition via sub-agents. This skill coordinates sub-agents with specialized
+  skills -- it does not build components directly.
+compatibility:
+  Requires @playwright/cli, Storybook running. Figma path requires FIGMA_TOKEN.
 ---
 
 # Clone Page into Canvas Components
-
-Orchestrate the full workflow of cloning a page from a URL or Figma design into
-Canvas components with visual QA verification.
 
 ## Content Fidelity Rule
 
 > **Text extracted in Phase 1 MUST be used character-for-character in Phase 3
 > (stories) and Phase 5 (page composition). NEVER generate, rephrase, or
 > summarize text. This is non-negotiable.**
-
-This rule exists because a previous migration hallucinated ALL body text after
-context compaction. Text must be persisted to files and copied verbatim.
+>
+> Repeat this rule to every sub-agent that handles text.
 
 ## Input
 
@@ -33,318 +30,127 @@ Output: docs/clone/ (default)
 
 Detect source type from the URL:
 
-- `figma.com/design/...` or `figma.com/make/...` → Figma path
-- Anything else → site URL path
+- `figma.com/design/...` or `figma.com/make/...` --> Figma path
+- Anything else --> site URL path
+
+## Phase Checklist
+
+- [ ] Phase 1: Extraction -- spawn sub-agent with `nebula-design-extraction` or
+      `nebula-figma-extraction`
+- [ ] Phase 2: Audit -- map sections to existing components (REUSE/ADAPT/BUILD)
+- [ ] Phase 3: Build -- spawn sub-agents for each BUILD component
+- [ ] Phase 4: Visual QA -- spawn sub-agent with `nebula-visual-qa`
+- [ ] Phase 5: Page story -- compose all components into example page
+- [ ] Phase 6: Upload (optional) -- spawn sub-agent with
+      `canvas-component-upload`
 
 ## Phase 1: Extraction
 
-### Site URL path
-
-Spawn a sub-agent to extract design data from the live site:
-
-```
-Agent tool:
-  prompt: "Load the nebula-design-extraction skill (invoke it via the Skill
-  tool). Extract design tokens, section screenshots, and verbatim content from
-  <URL>. Save all output to docs/clone/. Follow the skill's workflow exactly."
-```
-
-### Figma URL path
-
-Spawn a sub-agent to extract design data from Figma:
-
-```
-Agent tool:
-  prompt: "Load the nebula-figma-extraction skill (invoke it via the Skill
-  tool). Extract design tokens, frame screenshots, and verbatim content from
-  <FIGMA_URL>. Save all output to docs/clone/. Follow the skill's workflow
-  exactly."
-```
-
-### Verify Phase 1 output
+Spawn a sub-agent for the detected source type. See
+`references/sub-agent-prompts.md` for the exact prompt template.
 
 After the sub-agent completes, verify these artifacts exist:
 
-- `docs/clone/screenshots/desktop/` — at least full-page.png
+- `docs/clone/screenshots/desktop/` -- at least full-page.png
 - `docs/clone/design-tokens.md`
-- `docs/clone/content/` — at least one page content file
+- `docs/clone/content/` -- at least one page content file
 - `docs/clone/section-reference.md`
 
 If any are missing, check the sub-agent output for errors before proceeding.
-
-Update `docs/clone/progress.md`:
-
-```markdown
-# Clone Progress
-
-## Source
-
-URL: <source-url> Type: site | figma
-
-## Phase Status
-
-- [x] Phase 1: Extraction — completed
-- [ ] Phase 2: Audit
-- [ ] Phase 3: Build
-- [ ] Phase 4: QA
-- [ ] Phase 5: Page Story
-- [ ] Phase 6: Upload (optional)
-```
+Create `docs/clone/progress.md` (see `references/progress-template.md`).
 
 ## Phase 2: Audit & Map
 
-Handle this directly — no sub-agent needed.
+Handle directly -- no sub-agent needed.
 
-1. Read `docs/clone/section-reference.md` to understand what sections exist
+1. Read `docs/clone/section-reference.md` for section inventory
 2. Read `docs/clone/design-tokens.md` for the design system
 3. List existing components: read all `src/components/*/component.yml` files
-4. For each section, classify:
-   - **REUSE** — an existing component matches the section's needs
-   - **ADAPT** — an existing component needs a new variant or props
-   - **BUILD** — no existing component fits, need a new one
+4. Classify each section as REUSE, ADAPT, or BUILD
+5. Output `docs/clone/component-map.md` (see
+   `references/component-map-example.md`)
 
-5. Output `docs/clone/component-map.md`:
-
-```markdown
-# Component Map
-
-| Section  | Strategy | Component       | Notes                                 |
-| -------- | -------- | --------------- | ------------------------------------- |
-| Hero     | BUILD    | hero            | Full-width with background image, CTA |
-| Features | BUILD    | feature-card    | 3-column card grid                    |
-| About    | REUSE    | two-column-text | Existing component fits               |
-| CTA      | ADAPT    | section         | Add dark background variant           |
-| Footer   | REUSE    | footer          | Existing component fits               |
-```
-
-Update progress.md with audit results.
+Update progress.md.
 
 ## Phase 3: Build Components
 
-### Update global.css with design tokens
+Before building, add extracted design tokens to `src/components/global.css` as
+`@theme` variables.
 
-Before building components, add extracted design tokens to
-`src/components/global.css`:
+For each **BUILD** item in component-map.md, spawn a sub-agent. See
+`references/sub-agent-prompts.md` for the prompt template.
 
-```css
-@theme {
-  /* Colors from design-tokens.md */
-  --color-primary: #1a365d;
-  --color-accent: #e53e3e;
-  /* Typography */
-  --font-display: "Playfair Display", serif;
-  --font-body: "Inter", sans-serif;
-  /* ... */
-}
-```
+For each **ADAPT** item, add a new CVA variant, props, or slot to the existing
+component -- handle directly or spawn a sub-agent.
 
-### Build each component
+**Parallel execution:** Independent BUILD components can run as parallel
+sub-agents. Components with dependencies (e.g., a card importing a button) must
+be built sequentially -- dependency first.
 
-For each **BUILD** item in component-map.md, spawn a sub-agent:
-
-```
-Agent tool:
-  prompt: "Load these skills: canvas-component-definition,
-  canvas-component-metadata, canvas-styling-conventions,
-  nebula-component-creation, nebula-storybook-stories, and
-  nebula-frontend-design.
-
-  Build a <component-name> Canvas component matching the design in
-  docs/clone/screenshots/desktop/section-NN-<name>.png.
-
-  Use design tokens from docs/clone/design-tokens.md for all colors,
-  typography, and spacing. Map tokens to @theme variables in global.css and
-  use CVA variants for color/layout options.
-
-  Use VERBATIM text from docs/clone/content/<page>.md section NN for the
-  story args. DO NOT generate or rephrase any text.
-
-  Create: src/components/<name>/index.jsx, src/components/<name>/component.yml,
-  and the story file in src/stories/.
-
-  Run npm run code:fix and npx canvas validate after building."
-```
-
-For each **ADAPT** item, either spawn a sub-agent or handle directly — add a new
-CVA variant, additional props, or slot to the existing component.
-
-**Parallel execution:** Independent BUILD components can be spawned as
-background sub-agents. Components that depend on each other (e.g., a card that
-imports a button) must be built sequentially — dependency first.
-
-Update progress.md after each component is built.
+Update progress.md after each component.
 
 ## Phase 4: Visual QA Loop
 
-Spawn a sub-agent for visual comparison:
-
-```
-Agent tool:
-  prompt: "Load the nebula-visual-qa skill (invoke it via the Skill tool).
-
-  Compare Storybook renders against reference screenshots for these
-  components: <list from component-map.md>.
-
-  Reference screenshots: docs/clone/screenshots/
-  Design tokens: docs/clone/design-tokens.md
-  Storybook URL: http://localhost:6006
-
-  Run the full QA loop — fix issues until zero critical and zero high issues
-  remain. Document all issues in docs/clone/qa/issues/ and produce
-  docs/clone/qa/qa-summary.md when done."
-```
+Spawn a sub-agent with the visual QA prompt from
+`references/sub-agent-prompts.md`.
 
 After the sub-agent completes, read `docs/clone/qa/qa-summary.md`:
 
-- If zero critical/high issues → proceed to Phase 5
-- If critical/high issues remain → report to user for guidance
+- Zero critical/high issues --> proceed to Phase 5
+- Critical/high issues remain --> report to user for guidance
 
 Update progress.md.
 
 ## Phase 5: Compose Page Story
 
-Handle this directly — compose a page story using all built components.
+Handle directly. Create the page story at
+`src/stories/example-pages/<page-name>.stories.jsx`.
 
-1. Create or update `src/stories/example-pages/page-layout.jsx` if it doesn't
-   exist (see `nebula-page-stories` skill for the PageLayout pattern)
+See `references/page-story-example.md` for the full JSX template.
 
-2. Create the page story at `src/stories/example-pages/<page-name>.stories.jsx`:
-
-```jsx
-import FeatureCard from "@/components/feature-card";
-import Footer from "@/components/footer";
-import Hero from "@/components/hero";
-import Section from "@/components/section";
-import Spacer from "@/components/spacer";
-
-import PageLayout from "./page-layout";
-
-// Props use VERBATIM text from docs/clone/content/<page>.md
-const heroProps = {
-  heading: "Welcome to Our Company", // exact text from content file
-  subheading: "Building the future, one component at a time.",
-  ctaText: "Get Started",
-  ctaLink: "/contact",
-};
-
-const ClonedPage = () => (
-  <PageLayout>
-    <Hero {...heroProps} />
-    <Spacer height="large" />
-    <Section width="normal" content={<FeatureCard {...featureProps} />} />
-    <Spacer height="large" />
-    <Footer />
-  </PageLayout>
-);
-
-export default {
-  title: "Example pages/<Page Name>",
-  component: ClonedPage,
-  parameters: { layout: "fullscreen" },
-};
-
-export const Default = { name: "<Page Name>" };
-```
-
-3. Verify the page story renders in Storybook
+1. Create or update `src/stories/example-pages/page-layout.jsx` if needed
+2. Compose the page story using VERBATIM text from `docs/clone/content/`
+3. Verify it renders in Storybook
 
 Update progress.md.
 
 ## Phase 6: Upload (Optional)
 
-Only if the user requests it. Spawn a sub-agent:
-
-```
-Agent tool:
-  prompt: "Load the canvas-component-upload skill (invoke it via the Skill
-  tool). Run the preflight pipeline (code:fix → canvas:validate →
-  canvas:ssr-test) and upload these components: <list>.
-  Follow the skill's workflow exactly."
-```
+Only if the user requests it. Spawn a sub-agent with the upload prompt from
+`references/sub-agent-prompts.md`.
 
 ## Orchestrator Principles
 
-These principles are carried from the battle-tested migrate-site orchestrator:
+1. **Lightweight coordinator** -- read artifacts and spawn sub-agents. Do NOT
+   build components, extract CSS, or run visual comparisons directly.
 
-1. **Lightweight coordinator** — this skill reads artifacts and spawns
-   sub-agents. It does NOT build components, extract CSS, or perform visual
-   comparisons directly. All heavy lifting is delegated.
-
-2. **Verify after every phase** — check that expected output files exist before
+2. **Verify after every phase** -- check expected output files exist before
    moving to the next phase. If artifacts are missing, diagnose before
    proceeding.
 
-3. **Save evidence** — screenshots, QA reports, and progress file persist to
+3. **Save evidence** -- screenshots, QA reports, and progress file persist to
    disk. If context is compacted, artifacts survive.
 
-4. **Content fidelity** — verbatim text from Phase 1 is the single source of
+4. **Content fidelity** -- verbatim text from Phase 1 is the single source of
    truth. Repeat this rule to every sub-agent that handles text.
 
-5. **Exploration mindset** — when a sub-agent fails, read its output for
-   diagnostics. Investigate root cause before retrying or escalating to the
-   user.
-
-## Sub-Agent Spawning Reference
-
-When this skill says "spawn a sub-agent", use the Agent tool:
-
-1. In the `prompt`, tell the sub-agent:
-   - Which skill(s) to load (via the Skill tool)
-   - What specific task to perform
-   - What files to read as input
-   - What files to produce as output
-2. Wait for the sub-agent to complete
-3. Verify the expected output files exist
-4. If the sub-agent failed, read its output for diagnostics
-
-Sub-agents get their own context window — they don't see the orchestrator's full
-conversation. Provide all necessary context in the prompt.
-
-## Parallel Execution Opportunities
-
-```
-Phase 1: Single sub-agent (extraction)
-Phase 2: Orchestrator directly (sequential)
-Phase 3: Multiple sub-agents in parallel (one per independent BUILD component)
-Phase 4: Single sub-agent (QA needs all components)
-Phase 5: Orchestrator directly (sequential)
-Phase 6: Single sub-agent if requested (upload)
-```
-
-## Artifact Structure
-
-```
-docs/clone/
-├── progress.md
-├── component-map.md
-├── design-tokens.md
-├── section-reference.md
-├── media-map.md
-├── content/
-│   └── <page>.md
-├── screenshots/
-│   ├── desktop/
-│   ├── tablet/
-│   └── mobile/
-└── qa/
-    ├── issues/
-    │   └── 01-<description>/
-    │       ├── issue.md
-    │       ├── source.png
-    │       └── built.png
-    └── qa-summary.md
-```
+5. **Exploration mindset** -- when a sub-agent fails, read its output for
+   diagnostics. Investigate root cause before retrying or escalating.
 
 ## Scope
 
 This skill clones **one page at a time**. For multi-page sites, run it multiple
-times — components built in earlier runs are available for reuse in later ones.
+times -- components built in earlier runs are available for reuse.
 
-This is NOT a full site migration. It does not handle:
+This is NOT a full site migration. It does not handle CMS content composition,
+media upload to CMS, site configuration, or post-deployment verification. For
+those, use the migrate-site skill.
 
-- CMS content composition (JSON:API page creation)
-- Media upload to CMS
-- Site configuration (name, logo, favicon, menus)
-- Post-deployment verification on live sites
+## Reference Files
 
-For those, use the custom migrate-site skill in the project-specific repos.
+- `references/sub-agent-prompts.md` -- prompt templates for all sub-agents
+- `references/artifact-structure.md` -- full docs/clone/ directory tree
+- `references/progress-template.md` -- progress.md template
+- `references/page-story-example.md` -- page story JSX template
+- `references/component-map-example.md` -- component-map.md format and
+  classification rules

--- a/.agents/skills/nebula-clone-page/SKILL.md
+++ b/.agents/skills/nebula-clone-page/SKILL.md
@@ -1,0 +1,350 @@
+---
+name: nebula-clone-page
+description:
+  Clone a web page or Figma design into Canvas components with full visual QA.
+  Orchestrates extraction, component auditing, building, visual comparison, and
+  page story composition. Accepts a site URL or Figma URL. Use when the user
+  wants to recreate a page, section, or design as Canvas components in
+  Storybook. This skill coordinates sub-agents with specialized skills — it does
+  not build components directly.
+---
+
+# Clone Page into Canvas Components
+
+Orchestrate the full workflow of cloning a page from a URL or Figma design into
+Canvas components with visual QA verification.
+
+## Content Fidelity Rule
+
+> **Text extracted in Phase 1 MUST be used character-for-character in Phase 3
+> (stories) and Phase 5 (page composition). NEVER generate, rephrase, or
+> summarize text. This is non-negotiable.**
+
+This rule exists because a previous migration hallucinated ALL body text after
+context compaction. Text must be persisted to files and copied verbatim.
+
+## Input
+
+```
+Source: <site URL> or <Figma URL>
+Scope: full page (default) | specific sections | single component
+Output: docs/clone/ (default)
+```
+
+Detect source type from the URL:
+
+- `figma.com/design/...` or `figma.com/make/...` → Figma path
+- Anything else → site URL path
+
+## Phase 1: Extraction
+
+### Site URL path
+
+Spawn a sub-agent to extract design data from the live site:
+
+```
+Agent tool:
+  prompt: "Load the nebula-design-extraction skill (invoke it via the Skill
+  tool). Extract design tokens, section screenshots, and verbatim content from
+  <URL>. Save all output to docs/clone/. Follow the skill's workflow exactly."
+```
+
+### Figma URL path
+
+Spawn a sub-agent to extract design data from Figma:
+
+```
+Agent tool:
+  prompt: "Load the nebula-figma-extraction skill (invoke it via the Skill
+  tool). Extract design tokens, frame screenshots, and verbatim content from
+  <FIGMA_URL>. Save all output to docs/clone/. Follow the skill's workflow
+  exactly."
+```
+
+### Verify Phase 1 output
+
+After the sub-agent completes, verify these artifacts exist:
+
+- `docs/clone/screenshots/desktop/` — at least full-page.png
+- `docs/clone/design-tokens.md`
+- `docs/clone/content/` — at least one page content file
+- `docs/clone/section-reference.md`
+
+If any are missing, check the sub-agent output for errors before proceeding.
+
+Update `docs/clone/progress.md`:
+
+```markdown
+# Clone Progress
+
+## Source
+
+URL: <source-url> Type: site | figma
+
+## Phase Status
+
+- [x] Phase 1: Extraction — completed
+- [ ] Phase 2: Audit
+- [ ] Phase 3: Build
+- [ ] Phase 4: QA
+- [ ] Phase 5: Page Story
+- [ ] Phase 6: Upload (optional)
+```
+
+## Phase 2: Audit & Map
+
+Handle this directly — no sub-agent needed.
+
+1. Read `docs/clone/section-reference.md` to understand what sections exist
+2. Read `docs/clone/design-tokens.md` for the design system
+3. List existing components: read all `src/components/*/component.yml` files
+4. For each section, classify:
+   - **REUSE** — an existing component matches the section's needs
+   - **ADAPT** — an existing component needs a new variant or props
+   - **BUILD** — no existing component fits, need a new one
+
+5. Output `docs/clone/component-map.md`:
+
+```markdown
+# Component Map
+
+| Section  | Strategy | Component       | Notes                                 |
+| -------- | -------- | --------------- | ------------------------------------- |
+| Hero     | BUILD    | hero            | Full-width with background image, CTA |
+| Features | BUILD    | feature-card    | 3-column card grid                    |
+| About    | REUSE    | two-column-text | Existing component fits               |
+| CTA      | ADAPT    | section         | Add dark background variant           |
+| Footer   | REUSE    | footer          | Existing component fits               |
+```
+
+Update progress.md with audit results.
+
+## Phase 3: Build Components
+
+### Update global.css with design tokens
+
+Before building components, add extracted design tokens to
+`src/components/global.css`:
+
+```css
+@theme {
+  /* Colors from design-tokens.md */
+  --color-primary: #1a365d;
+  --color-accent: #e53e3e;
+  /* Typography */
+  --font-display: "Playfair Display", serif;
+  --font-body: "Inter", sans-serif;
+  /* ... */
+}
+```
+
+### Build each component
+
+For each **BUILD** item in component-map.md, spawn a sub-agent:
+
+```
+Agent tool:
+  prompt: "Load these skills: canvas-component-definition,
+  canvas-component-metadata, canvas-styling-conventions,
+  nebula-component-creation, nebula-storybook-stories, and
+  nebula-frontend-design.
+
+  Build a <component-name> Canvas component matching the design in
+  docs/clone/screenshots/desktop/section-NN-<name>.png.
+
+  Use design tokens from docs/clone/design-tokens.md for all colors,
+  typography, and spacing. Map tokens to @theme variables in global.css and
+  use CVA variants for color/layout options.
+
+  Use VERBATIM text from docs/clone/content/<page>.md section NN for the
+  story args. DO NOT generate or rephrase any text.
+
+  Create: src/components/<name>/index.jsx, src/components/<name>/component.yml,
+  and the story file in src/stories/.
+
+  Run npm run code:fix and npx canvas validate after building."
+```
+
+For each **ADAPT** item, either spawn a sub-agent or handle directly — add a new
+CVA variant, additional props, or slot to the existing component.
+
+**Parallel execution:** Independent BUILD components can be spawned as
+background sub-agents. Components that depend on each other (e.g., a card that
+imports a button) must be built sequentially — dependency first.
+
+Update progress.md after each component is built.
+
+## Phase 4: Visual QA Loop
+
+Spawn a sub-agent for visual comparison:
+
+```
+Agent tool:
+  prompt: "Load the nebula-visual-qa skill (invoke it via the Skill tool).
+
+  Compare Storybook renders against reference screenshots for these
+  components: <list from component-map.md>.
+
+  Reference screenshots: docs/clone/screenshots/
+  Design tokens: docs/clone/design-tokens.md
+  Storybook URL: http://localhost:6006
+
+  Run the full QA loop — fix issues until zero critical and zero high issues
+  remain. Document all issues in docs/clone/qa/issues/ and produce
+  docs/clone/qa/qa-summary.md when done."
+```
+
+After the sub-agent completes, read `docs/clone/qa/qa-summary.md`:
+
+- If zero critical/high issues → proceed to Phase 5
+- If critical/high issues remain → report to user for guidance
+
+Update progress.md.
+
+## Phase 5: Compose Page Story
+
+Handle this directly — compose a page story using all built components.
+
+1. Create or update `src/stories/example-pages/page-layout.jsx` if it doesn't
+   exist (see `nebula-page-stories` skill for the PageLayout pattern)
+
+2. Create the page story at `src/stories/example-pages/<page-name>.stories.jsx`:
+
+```jsx
+import FeatureCard from "@/components/feature-card";
+import Footer from "@/components/footer";
+import Hero from "@/components/hero";
+import Section from "@/components/section";
+import Spacer from "@/components/spacer";
+
+import PageLayout from "./page-layout";
+
+// Props use VERBATIM text from docs/clone/content/<page>.md
+const heroProps = {
+  heading: "Welcome to Our Company", // exact text from content file
+  subheading: "Building the future, one component at a time.",
+  ctaText: "Get Started",
+  ctaLink: "/contact",
+};
+
+const ClonedPage = () => (
+  <PageLayout>
+    <Hero {...heroProps} />
+    <Spacer height="large" />
+    <Section width="normal" content={<FeatureCard {...featureProps} />} />
+    <Spacer height="large" />
+    <Footer />
+  </PageLayout>
+);
+
+export default {
+  title: "Example pages/<Page Name>",
+  component: ClonedPage,
+  parameters: { layout: "fullscreen" },
+};
+
+export const Default = { name: "<Page Name>" };
+```
+
+3. Verify the page story renders in Storybook
+
+Update progress.md.
+
+## Phase 6: Upload (Optional)
+
+Only if the user requests it. Spawn a sub-agent:
+
+```
+Agent tool:
+  prompt: "Load the canvas-component-upload skill (invoke it via the Skill
+  tool). Run the preflight pipeline (code:fix → canvas:validate →
+  canvas:ssr-test) and upload these components: <list>.
+  Follow the skill's workflow exactly."
+```
+
+## Orchestrator Principles
+
+These principles are carried from the battle-tested migrate-site orchestrator:
+
+1. **Lightweight coordinator** — this skill reads artifacts and spawns
+   sub-agents. It does NOT build components, extract CSS, or perform visual
+   comparisons directly. All heavy lifting is delegated.
+
+2. **Verify after every phase** — check that expected output files exist before
+   moving to the next phase. If artifacts are missing, diagnose before
+   proceeding.
+
+3. **Save evidence** — screenshots, QA reports, and progress file persist to
+   disk. If context is compacted, artifacts survive.
+
+4. **Content fidelity** — verbatim text from Phase 1 is the single source of
+   truth. Repeat this rule to every sub-agent that handles text.
+
+5. **Exploration mindset** — when a sub-agent fails, read its output for
+   diagnostics. Investigate root cause before retrying or escalating to the
+   user.
+
+## Sub-Agent Spawning Reference
+
+When this skill says "spawn a sub-agent", use the Agent tool:
+
+1. In the `prompt`, tell the sub-agent:
+   - Which skill(s) to load (via the Skill tool)
+   - What specific task to perform
+   - What files to read as input
+   - What files to produce as output
+2. Wait for the sub-agent to complete
+3. Verify the expected output files exist
+4. If the sub-agent failed, read its output for diagnostics
+
+Sub-agents get their own context window — they don't see the orchestrator's full
+conversation. Provide all necessary context in the prompt.
+
+## Parallel Execution Opportunities
+
+```
+Phase 1: Single sub-agent (extraction)
+Phase 2: Orchestrator directly (sequential)
+Phase 3: Multiple sub-agents in parallel (one per independent BUILD component)
+Phase 4: Single sub-agent (QA needs all components)
+Phase 5: Orchestrator directly (sequential)
+Phase 6: Single sub-agent if requested (upload)
+```
+
+## Artifact Structure
+
+```
+docs/clone/
+├── progress.md
+├── component-map.md
+├── design-tokens.md
+├── section-reference.md
+├── media-map.md
+├── content/
+│   └── <page>.md
+├── screenshots/
+│   ├── desktop/
+│   ├── tablet/
+│   └── mobile/
+└── qa/
+    ├── issues/
+    │   └── 01-<description>/
+    │       ├── issue.md
+    │       ├── source.png
+    │       └── built.png
+    └── qa-summary.md
+```
+
+## Scope
+
+This skill clones **one page at a time**. For multi-page sites, run it multiple
+times — components built in earlier runs are available for reuse in later ones.
+
+This is NOT a full site migration. It does not handle:
+
+- CMS content composition (JSON:API page creation)
+- Media upload to CMS
+- Site configuration (name, logo, favicon, menus)
+- Post-deployment verification on live sites
+
+For those, use the custom migrate-site skill in the project-specific repos.

--- a/.agents/skills/nebula-clone-page/references/artifact-structure.md
+++ b/.agents/skills/nebula-clone-page/references/artifact-structure.md
@@ -1,0 +1,23 @@
+# Artifact Structure
+
+```
+docs/clone/
+├── progress.md
+├── component-map.md
+├── design-tokens.md
+├── section-reference.md
+├── media-map.md
+├── content/
+│   └── <page>.md
+├── screenshots/
+│   ├── desktop/
+│   ├── tablet/
+│   └── mobile/
+└── qa/
+    ├── issues/
+    │   └── 01-<description>/
+    │       ├── issue.md
+    │       ├── source.png
+    │       └── built.png
+    └── qa-summary.md
+```

--- a/.agents/skills/nebula-clone-page/references/component-map-example.md
+++ b/.agents/skills/nebula-clone-page/references/component-map-example.md
@@ -1,0 +1,23 @@
+# Component Map Example
+
+Output `docs/clone/component-map.md` with this format:
+
+```markdown
+# Component Map
+
+| Section  | Strategy | Component       | Notes                                 |
+| -------- | -------- | --------------- | ------------------------------------- |
+| Hero     | BUILD    | hero            | Full-width with background image, CTA |
+| Features | BUILD    | feature-card    | 3-column card grid                    |
+| About    | REUSE    | two-column-text | Existing component fits               |
+| CTA      | ADAPT    | section         | Add dark background variant           |
+| Footer   | REUSE    | footer          | Existing component fits               |
+```
+
+## Classification Rules
+
+For each section identified in `docs/clone/section-reference.md`:
+
+- **REUSE** -- an existing component matches the section's needs exactly
+- **ADAPT** -- an existing component needs a new variant, props, or slot
+- **BUILD** -- no existing component fits; create a new one

--- a/.agents/skills/nebula-clone-page/references/page-story-example.md
+++ b/.agents/skills/nebula-clone-page/references/page-story-example.md
@@ -1,0 +1,45 @@
+# Page Story Example
+
+Create the page story at `src/stories/example-pages/<page-name>.stories.jsx`:
+
+```jsx
+import FeatureCard from "@/components/feature-card";
+import Footer from "@/components/footer";
+import Hero from "@/components/hero";
+import Section from "@/components/section";
+import Spacer from "@/components/spacer";
+
+import PageLayout from "./page-layout";
+
+// Props use VERBATIM text from docs/clone/content/<page>.md
+const heroProps = {
+  heading: "Welcome to Our Company", // exact text from content file
+  subheading: "Building the future, one component at a time.",
+  ctaText: "Get Started",
+  ctaLink: "/contact",
+};
+
+const ClonedPage = () => (
+  <PageLayout>
+    <Hero {...heroProps} />
+    <Spacer height="large" />
+    <Section width="normal" content={<FeatureCard {...featureProps} />} />
+    <Spacer height="large" />
+    <Footer />
+  </PageLayout>
+);
+
+export default {
+  title: "Example pages/<Page Name>",
+  component: ClonedPage,
+  parameters: { layout: "fullscreen" },
+};
+
+export const Default = { name: "<Page Name>" };
+```
+
+Notes:
+
+- Create or update `src/stories/example-pages/page-layout.jsx` if it doesn't
+  exist (see `nebula-page-stories` skill for the PageLayout pattern)
+- Verify the page story renders in Storybook after creation

--- a/.agents/skills/nebula-clone-page/references/progress-template.md
+++ b/.agents/skills/nebula-clone-page/references/progress-template.md
@@ -1,0 +1,21 @@
+# Progress Template
+
+Create `docs/clone/progress.md` after Phase 1 completes. Update after each
+phase.
+
+```markdown
+# Clone Progress
+
+## Source
+
+URL: <source-url> Type: site | figma
+
+## Phase Status
+
+- [x] Phase 1: Extraction — completed
+- [ ] Phase 2: Audit
+- [ ] Phase 3: Build
+- [ ] Phase 4: QA
+- [ ] Phase 5: Page Story
+- [ ] Phase 6: Upload (optional)
+```

--- a/.agents/skills/nebula-clone-page/references/sub-agent-prompts.md
+++ b/.agents/skills/nebula-clone-page/references/sub-agent-prompts.md
@@ -1,0 +1,84 @@
+# Sub-Agent Prompt Templates
+
+Use these prompt templates with the Agent tool when spawning sub-agents.
+
+## Phase 1: Site URL Extraction
+
+```
+Load the nebula-design-extraction skill (invoke it via the Skill tool).
+Extract design tokens, section screenshots, and verbatim content from <URL>.
+Save all output to docs/clone/. Follow the skill's workflow exactly.
+```
+
+## Phase 1: Figma Extraction
+
+```
+Load the nebula-figma-extraction skill (invoke it via the Skill tool).
+Extract design tokens, frame screenshots, and verbatim content from <FIGMA_URL>.
+Save all output to docs/clone/. Follow the skill's workflow exactly.
+```
+
+## Phase 3: Build Component
+
+```
+Load these skills: canvas-component-definition, canvas-component-metadata,
+canvas-styling-conventions, nebula-component-creation, nebula-storybook-stories,
+and nebula-frontend-design.
+
+Build a <component-name> Canvas component matching the design in
+docs/clone/screenshots/desktop/section-NN-<name>.png.
+
+Use design tokens from docs/clone/design-tokens.md for all colors, typography,
+and spacing. Map tokens to @theme variables in global.css and use CVA variants
+for color/layout options.
+
+Use VERBATIM text from docs/clone/content/<page>.md section NN for the story
+args. DO NOT generate or rephrase any text.
+
+Create: src/components/<name>/index.jsx, src/components/<name>/component.yml,
+and the story file in src/stories/.
+
+Run npm run code:fix and npx canvas validate after building.
+```
+
+## Phase 4: Visual QA
+
+```
+Load the nebula-visual-qa skill (invoke it via the Skill tool).
+
+Compare Storybook renders against reference screenshots for these components:
+<list from component-map.md>.
+
+Reference screenshots: docs/clone/screenshots/
+Design tokens: docs/clone/design-tokens.md
+Storybook URL: http://localhost:6006
+
+Run the full QA loop — fix issues until zero critical and zero high issues
+remain. Document all issues in docs/clone/qa/issues/ and produce
+docs/clone/qa/qa-summary.md when done.
+```
+
+## Phase 6: Upload
+
+```
+Load the canvas-component-upload skill (invoke it via the Skill tool).
+Run the preflight pipeline (code:fix -> canvas:validate -> canvas:ssr-test) and
+upload these components: <list>.
+Follow the skill's workflow exactly.
+```
+
+## Sub-Agent Spawning Rules
+
+When this skill says "spawn a sub-agent", use the Agent tool:
+
+1. In the `prompt`, tell the sub-agent:
+   - Which skill(s) to load (via the Skill tool)
+   - What specific task to perform
+   - What files to read as input
+   - What files to produce as output
+2. Wait for the sub-agent to complete
+3. Verify the expected output files exist
+4. If the sub-agent failed, read its output for diagnostics
+
+Sub-agents get their own context window — they don't see the orchestrator's full
+conversation. Provide all necessary context in the prompt.

--- a/.agents/skills/nebula-design-extraction/SKILL.md
+++ b/.agents/skills/nebula-design-extraction/SKILL.md
@@ -3,282 +3,94 @@ name: nebula-design-extraction
 description:
   Extract design tokens, section screenshots, verbatim content, and responsive
   CSS from a live website URL. Use when cloning a page, extracting a design
-  system from an existing site, or capturing structured reference data for
-  component building. Produces design-tokens.md, content files, section
-  screenshots, and a section reference map. Requires Playwright CLI.
+  system, or capturing structured reference data for component building.
+compatibility: Requires @playwright/cli. Target URL must be accessible.
 ---
 
 # Design Extraction from a Live Site
 
-Extract structured design data from a website URL. This skill captures
-screenshots, design tokens, verbatim text content, and responsive CSS — the raw
-materials needed to build Canvas components that match the source.
+> **CONTENT FIDELITY RULE — ALL text must be extracted character-for-character
+> from the source. NEVER rephrase, summarize, correct typos, or generate text.
+> If text cannot be read, mark it as `[UNREADABLE]` rather than guessing.** Text
+> extracted here will be used verbatim downstream. Any rephrasing introduces
+> hallucinated content.
 
 ## Prerequisites
 
 - Playwright CLI installed (`@playwright/cli` — included in Nebula)
-- Target URL accessible
+- Target URL accessible from the execution environment
 
 ## Arguments
 
-- `$1` — **URL** (required). The page to extract from.
-- `$2` — **Output directory** (optional). Defaults to `docs/clone/`.
-
-## Content Fidelity Rule
-
-> **ALL text must be extracted character-for-character from the source. NEVER
-> rephrase, summarize, correct typos, or generate text. If text cannot be read,
-> mark it as `[UNREADABLE]` rather than guessing.**
-
-This is non-negotiable. Text extracted here will be used verbatim in component
-stories and page compositions. Any rephrasing introduces hallucinated content.
+| Arg  | Required | Description                              |
+| ---- | -------- | ---------------------------------------- |
+| `$1` | Yes      | URL of the page to extract from          |
+| `$2` | No       | Output directory (default `docs/clone/`) |
 
 ## Workflow
 
-### Step 1: Full-page capture at multiple viewports
+- [ ] Open URL: `playwright-cli open <url> -s=extract`
+- [ ] Full-page screenshots at desktop (1280), tablet (768), mobile (375)
+- [ ] Identify page sections from snapshot (`playwright-cli snapshot`)
+- [ ] Assign section IDs: `section-01-hero`, `section-02-features`, etc.
+- [ ] Per-section screenshots at desktop + mobile
+- [ ] Extract verbatim text content per section (see
+      `references/content-example.md`)
+- [ ] Extract computed CSS for design tokens (see
+      `references/css-extraction-commands.md`)
+- [ ] Generate `design-tokens.md` (see `references/design-tokens-example.md`)
+- [ ] Generate `section-reference.md` (see `references/output-formats.md`)
+- [ ] Generate `media-map.md` (see `references/output-formats.md`)
+- [ ] Close browser: `playwright-cli close -s=extract`
 
-```bash
-playwright-cli open <url> -s=extract
-playwright-cli screenshot --full-page --filename=screenshots/desktop/full-page.png -s=extract
-playwright-cli resize 768 1024 -s=extract
-playwright-cli screenshot --full-page --filename=screenshots/tablet/full-page.png -s=extract
-playwright-cli resize 375 812 -s=extract
-playwright-cli screenshot --full-page --filename=screenshots/mobile/full-page.png -s=extract
-```
+### Section identification
 
-### Step 2: Identify page sections
-
-```bash
-# Reset to desktop viewport
-playwright-cli resize 1280 900 -s=extract
-# Get page structure
-playwright-cli snapshot -s=extract
-```
-
-Read the snapshot to identify major semantic sections: hero, features, about,
-testimonials, CTA, footer, etc. Sections are typically identified by:
+Sections are identified by:
 
 - `<section>`, `<header>`, `<footer>`, `<main>` elements
 - Heading elements (`h1`-`h6`) that introduce new content blocks
 - Major layout containers with distinct visual purposes
 - Landmark roles in the accessibility tree
 
-Assign section numbers: `section-01-hero`, `section-02-features`, etc.
-
-### Step 3: Per-section screenshots
-
-For each identified section, capture at desktop and mobile viewports:
+### Screenshot commands
 
 ```bash
-# Desktop (1280px) — should already be at this viewport
-playwright-cli screenshot <section-ref> --filename=screenshots/desktop/section-01-hero.png -s=extract
+# Full-page at each viewport
+playwright-cli screenshot --full-page --filename=screenshots/desktop/full-page.png -s=extract
+playwright-cli resize 768 1024 -s=extract
+playwright-cli screenshot --full-page --filename=screenshots/tablet/full-page.png -s=extract
+playwright-cli resize 375 812 -s=extract
+playwright-cli screenshot --full-page --filename=screenshots/mobile/full-page.png -s=extract
 
-# Mobile (375px)
+# Per-section (repeat for each section at desktop + mobile)
+playwright-cli resize 1280 900 -s=extract
+playwright-cli screenshot <section-ref> --filename=screenshots/desktop/section-01-hero.png -s=extract
 playwright-cli resize 375 812 -s=extract
 playwright-cli screenshot <section-ref> --filename=screenshots/mobile/section-01-hero.png -s=extract
-
-# Reset for next section
-playwright-cli resize 1280 900 -s=extract
 ```
 
-If element-level screenshots aren't possible, scroll to each section and capture
-the viewport instead.
-
-### Step 4: Extract verbatim text content
-
-For each section, extract ALL visible text exactly as it appears. Output to
-`content/<page-name>.md`:
-
-```markdown
-# <Page Title>
-
-## Section 1: Hero
-
-<!-- Context: Full-width hero with dark background overlay -->
-<!-- Layout: Centered text, CTA button below -->
-<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
-
-### Heading
-
-Welcome to Our Company
-
-### Subheading
-
-Building the future, one component at a time.
-
-### CTA Button
-
-Get Started → /contact
-
-### Background Image
-
-hero-bg.jpg (https://example.com/images/hero-bg.jpg)
-
----
-
-## Section 2: Features
-
-<!-- Context: 3-column card grid on light background -->
-<!-- Layout: Grid, 3 cols desktop, stacked mobile -->
-<!-- Screenshot: screenshots/desktop/section-02-features.png -->
-
-### Card 1
-
-**Title:** Fast Development **Body:** Build components quickly with our modern
-toolchain. **Image:** /images/fast-dev.jpg (alt: Developer working on laptop)
-
-### Card 2
-
-**Title:** Responsive Design **Body:** Every component works perfectly on all
-screen sizes. **Image:** /images/responsive.jpg (alt: Devices showing responsive
-layout)
-```
-
-Each section includes metadata comments for Context, Layout, and Screenshot
-paths. Text is extracted character-for-character.
-
-### Step 5: Extract computed CSS for design tokens
-
-For key elements in each section, extract computed styles at multiple viewports.
-Use `eval` to run JavaScript in the page context:
-
-```bash
-# Colors
-playwright-cli eval "getComputedStyle(document.querySelector('.hero')).backgroundColor" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('.hero')).color" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).color" -s=extract
-
-# Typography
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontFamily" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontSize" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontWeight" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).lineHeight" -s=extract
-
-# Spacing
-playwright-cli eval "getComputedStyle(document.querySelector('section')).padding" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('.container')).maxWidth" -s=extract
-
-# Effects
-playwright-cli eval "getComputedStyle(document.querySelector('.card')).boxShadow" -s=extract
-playwright-cli eval "getComputedStyle(document.querySelector('.card')).borderRadius" -s=extract
-```
-
-Repeat at mobile viewport (375px) to capture responsive changes.
-
-### Step 6: Generate design-tokens.md
-
-Synthesize the extracted CSS into a structured tokens file:
-
-```markdown
-# Design Tokens
-
-## Colors
-
-| Token      | Value   | Usage                    |
-| ---------- | ------- | ------------------------ |
-| primary    | #1a365d | Headings, nav background |
-| accent     | #e53e3e | CTA buttons, highlights  |
-| background | #f7fafc | Page background          |
-| text       | #2d3748 | Body text                |
-| text-light | #718096 | Captions, secondary text |
-
-## Typography
-
-| Element | Font             | Size (desktop) | Size (mobile) | Weight | Line Height |
-| ------- | ---------------- | -------------- | ------------- | ------ | ----------- |
-| h1      | Playfair Display | 3rem           | 2rem          | 700    | 1.2         |
-| h2      | Playfair Display | 2.25rem        | 1.5rem        | 600    | 1.3         |
-| body    | Inter            | 1rem           | 1rem          | 400    | 1.6         |
-| small   | Inter            | 0.875rem       | 0.875rem      | 400    | 1.5         |
-
-## Spacing
-
-| Context             | Desktop  | Mobile    |
-| ------------------- | -------- | --------- |
-| Section padding     | 80px 0   | 40px 16px |
-| Container max-width | 1200px   | 100%      |
-| Card gap            | 24px     | 16px      |
-| Standard unit       | 8px grid | 8px grid  |
-
-## Effects
-
-| Effect                  | Value                     |
-| ----------------------- | ------------------------- |
-| Card shadow             | 0 4px 6px rgba(0,0,0,0.1) |
-| Border radius (cards)   | 12px                      |
-| Border radius (buttons) | 8px                       |
-| Hover transition        | 200ms ease-in-out         |
-```
-
-### Step 7: Generate section-reference.md
-
-Map each section to its screenshots, content, and structural notes:
-
-```markdown
-# Section Reference
-
-| #   | Section  | Type        | Desktop Screenshot      | Mobile Screenshot       | Component Hint        |
-| --- | -------- | ----------- | ----------------------- | ----------------------- | --------------------- |
-| 1   | Hero     | Hero banner | section-01-hero.png     | section-01-hero.png     | hero                  |
-| 2   | Features | Card grid   | section-02-features.png | section-02-features.png | card_container + card |
-| 3   | About    | Two-column  | section-03-about.png    | section-03-about.png    | two_column_text       |
-| 4   | CTA      | Banner      | section-04-cta.png      | section-04-cta.png      | section + button      |
-```
-
-### Step 8: Generate media-map.md
-
-List all images, videos, and media assets found on the page:
-
-```markdown
-# Media Map
-
-| #   | Filename     | Source URL                              | Alt Text            | Section  | Type       |
-| --- | ------------ | --------------------------------------- | ------------------- | -------- | ---------- |
-| 1   | hero-bg.jpg  | https://example.com/images/hero-bg.jpg  | Mountain landscape  | Hero     | background |
-| 2   | fast-dev.jpg | https://example.com/images/fast-dev.jpg | Developer on laptop | Features | content    |
-| 3   | logo.svg     | https://example.com/images/logo.svg     | Company Logo        | Header   | logo       |
-```
+If element-level screenshots are not possible, scroll to each section and
+capture the viewport instead.
 
 ## Output Artifacts
 
 All output goes to the specified output directory (default `docs/clone/`):
 
-```
-docs/clone/
-├── screenshots/
-│   ├── desktop/
-│   │   ├── full-page.png
-│   │   ├── section-01-hero.png
-│   │   ├── section-02-features.png
-│   │   └── ...
-│   ├── tablet/
-│   │   └── full-page.png
-│   └── mobile/
-│       ├── full-page.png
-│       ├── section-01-hero.png
-│       └── ...
-├── content/
-│   └── <page-name>.md
-├── design-tokens.md
-├── section-reference.md
-└── media-map.md
-```
+| File                     | Purpose                                          |
+| ------------------------ | ------------------------------------------------ |
+| `screenshots/desktop/`   | Full-page + per-section screenshots at 1280px    |
+| `screenshots/tablet/`    | Full-page screenshot at 768px                    |
+| `screenshots/mobile/`    | Full-page + per-section screenshots at 375px     |
+| `content/<page-name>.md` | Verbatim text content organized by section       |
+| `design-tokens.md`       | Colors, typography, spacing, effects             |
+| `section-reference.md`   | Section-to-screenshot-to-component mapping table |
+| `media-map.md`           | All images/videos with source URLs and alt text  |
 
-## Cleanup
+## Usage
 
-```bash
-playwright-cli close -s=extract
-```
+**Standalone:** Extract a site's design system for research, competitive
+analysis, or client audits without intending to clone.
 
-## Standalone Usage
-
-This skill can be used independently for design research — extracting a site's
-design system without intending to clone it. Useful for competitive analysis,
-client site audits, or extracting tokens from an existing site to match in new
-components.
-
-## Usage as Sub-Agent (via nebula-clone-page)
-
-When spawned by the `nebula-clone-page` orchestrator, the orchestrator provides
-the URL and output directory. This skill runs the full extraction workflow and
-the orchestrator reads the output artifacts for the next phase.
+**Sub-agent (via nebula-clone-page):** The orchestrator provides URL and output
+directory; this skill runs the full extraction and the orchestrator reads output
+artifacts for the next phase.

--- a/.agents/skills/nebula-design-extraction/SKILL.md
+++ b/.agents/skills/nebula-design-extraction/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: nebula-design-extraction
+description:
+  Extract design tokens, section screenshots, verbatim content, and responsive
+  CSS from a live website URL. Use when cloning a page, extracting a design
+  system from an existing site, or capturing structured reference data for
+  component building. Produces design-tokens.md, content files, section
+  screenshots, and a section reference map. Requires Playwright CLI.
+---
+
+# Design Extraction from a Live Site
+
+Extract structured design data from a website URL. This skill captures
+screenshots, design tokens, verbatim text content, and responsive CSS — the raw
+materials needed to build Canvas components that match the source.
+
+## Prerequisites
+
+- Playwright CLI installed (`@playwright/cli` — included in Nebula)
+- Target URL accessible
+
+## Arguments
+
+- `$1` — **URL** (required). The page to extract from.
+- `$2` — **Output directory** (optional). Defaults to `docs/clone/`.
+
+## Content Fidelity Rule
+
+> **ALL text must be extracted character-for-character from the source. NEVER
+> rephrase, summarize, correct typos, or generate text. If text cannot be read,
+> mark it as `[UNREADABLE]` rather than guessing.**
+
+This is non-negotiable. Text extracted here will be used verbatim in component
+stories and page compositions. Any rephrasing introduces hallucinated content.
+
+## Workflow
+
+### Step 1: Full-page capture at multiple viewports
+
+```bash
+playwright-cli open <url> -s=extract
+playwright-cli screenshot --full-page --filename=screenshots/desktop/full-page.png -s=extract
+playwright-cli resize 768 1024 -s=extract
+playwright-cli screenshot --full-page --filename=screenshots/tablet/full-page.png -s=extract
+playwright-cli resize 375 812 -s=extract
+playwright-cli screenshot --full-page --filename=screenshots/mobile/full-page.png -s=extract
+```
+
+### Step 2: Identify page sections
+
+```bash
+# Reset to desktop viewport
+playwright-cli resize 1280 900 -s=extract
+# Get page structure
+playwright-cli snapshot -s=extract
+```
+
+Read the snapshot to identify major semantic sections: hero, features, about,
+testimonials, CTA, footer, etc. Sections are typically identified by:
+
+- `<section>`, `<header>`, `<footer>`, `<main>` elements
+- Heading elements (`h1`-`h6`) that introduce new content blocks
+- Major layout containers with distinct visual purposes
+- Landmark roles in the accessibility tree
+
+Assign section numbers: `section-01-hero`, `section-02-features`, etc.
+
+### Step 3: Per-section screenshots
+
+For each identified section, capture at desktop and mobile viewports:
+
+```bash
+# Desktop (1280px) — should already be at this viewport
+playwright-cli screenshot <section-ref> --filename=screenshots/desktop/section-01-hero.png -s=extract
+
+# Mobile (375px)
+playwright-cli resize 375 812 -s=extract
+playwright-cli screenshot <section-ref> --filename=screenshots/mobile/section-01-hero.png -s=extract
+
+# Reset for next section
+playwright-cli resize 1280 900 -s=extract
+```
+
+If element-level screenshots aren't possible, scroll to each section and capture
+the viewport instead.
+
+### Step 4: Extract verbatim text content
+
+For each section, extract ALL visible text exactly as it appears. Output to
+`content/<page-name>.md`:
+
+```markdown
+# <Page Title>
+
+## Section 1: Hero
+
+<!-- Context: Full-width hero with dark background overlay -->
+<!-- Layout: Centered text, CTA button below -->
+<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
+
+### Heading
+
+Welcome to Our Company
+
+### Subheading
+
+Building the future, one component at a time.
+
+### CTA Button
+
+Get Started → /contact
+
+### Background Image
+
+hero-bg.jpg (https://example.com/images/hero-bg.jpg)
+
+---
+
+## Section 2: Features
+
+<!-- Context: 3-column card grid on light background -->
+<!-- Layout: Grid, 3 cols desktop, stacked mobile -->
+<!-- Screenshot: screenshots/desktop/section-02-features.png -->
+
+### Card 1
+
+**Title:** Fast Development **Body:** Build components quickly with our modern
+toolchain. **Image:** /images/fast-dev.jpg (alt: Developer working on laptop)
+
+### Card 2
+
+**Title:** Responsive Design **Body:** Every component works perfectly on all
+screen sizes. **Image:** /images/responsive.jpg (alt: Devices showing responsive
+layout)
+```
+
+Each section includes metadata comments for Context, Layout, and Screenshot
+paths. Text is extracted character-for-character.
+
+### Step 5: Extract computed CSS for design tokens
+
+For key elements in each section, extract computed styles at multiple viewports.
+Use `eval` to run JavaScript in the page context:
+
+```bash
+# Colors
+playwright-cli eval "getComputedStyle(document.querySelector('.hero')).backgroundColor" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.hero')).color" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).color" -s=extract
+
+# Typography
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontFamily" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontSize" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontWeight" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).lineHeight" -s=extract
+
+# Spacing
+playwright-cli eval "getComputedStyle(document.querySelector('section')).padding" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.container')).maxWidth" -s=extract
+
+# Effects
+playwright-cli eval "getComputedStyle(document.querySelector('.card')).boxShadow" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.card')).borderRadius" -s=extract
+```
+
+Repeat at mobile viewport (375px) to capture responsive changes.
+
+### Step 6: Generate design-tokens.md
+
+Synthesize the extracted CSS into a structured tokens file:
+
+```markdown
+# Design Tokens
+
+## Colors
+
+| Token      | Value   | Usage                    |
+| ---------- | ------- | ------------------------ |
+| primary    | #1a365d | Headings, nav background |
+| accent     | #e53e3e | CTA buttons, highlights  |
+| background | #f7fafc | Page background          |
+| text       | #2d3748 | Body text                |
+| text-light | #718096 | Captions, secondary text |
+
+## Typography
+
+| Element | Font             | Size (desktop) | Size (mobile) | Weight | Line Height |
+| ------- | ---------------- | -------------- | ------------- | ------ | ----------- |
+| h1      | Playfair Display | 3rem           | 2rem          | 700    | 1.2         |
+| h2      | Playfair Display | 2.25rem        | 1.5rem        | 600    | 1.3         |
+| body    | Inter            | 1rem           | 1rem          | 400    | 1.6         |
+| small   | Inter            | 0.875rem       | 0.875rem      | 400    | 1.5         |
+
+## Spacing
+
+| Context             | Desktop  | Mobile    |
+| ------------------- | -------- | --------- |
+| Section padding     | 80px 0   | 40px 16px |
+| Container max-width | 1200px   | 100%      |
+| Card gap            | 24px     | 16px      |
+| Standard unit       | 8px grid | 8px grid  |
+
+## Effects
+
+| Effect                  | Value                     |
+| ----------------------- | ------------------------- |
+| Card shadow             | 0 4px 6px rgba(0,0,0,0.1) |
+| Border radius (cards)   | 12px                      |
+| Border radius (buttons) | 8px                       |
+| Hover transition        | 200ms ease-in-out         |
+```
+
+### Step 7: Generate section-reference.md
+
+Map each section to its screenshots, content, and structural notes:
+
+```markdown
+# Section Reference
+
+| #   | Section  | Type        | Desktop Screenshot      | Mobile Screenshot       | Component Hint        |
+| --- | -------- | ----------- | ----------------------- | ----------------------- | --------------------- |
+| 1   | Hero     | Hero banner | section-01-hero.png     | section-01-hero.png     | hero                  |
+| 2   | Features | Card grid   | section-02-features.png | section-02-features.png | card_container + card |
+| 3   | About    | Two-column  | section-03-about.png    | section-03-about.png    | two_column_text       |
+| 4   | CTA      | Banner      | section-04-cta.png      | section-04-cta.png      | section + button      |
+```
+
+### Step 8: Generate media-map.md
+
+List all images, videos, and media assets found on the page:
+
+```markdown
+# Media Map
+
+| #   | Filename     | Source URL                              | Alt Text            | Section  | Type       |
+| --- | ------------ | --------------------------------------- | ------------------- | -------- | ---------- |
+| 1   | hero-bg.jpg  | https://example.com/images/hero-bg.jpg  | Mountain landscape  | Hero     | background |
+| 2   | fast-dev.jpg | https://example.com/images/fast-dev.jpg | Developer on laptop | Features | content    |
+| 3   | logo.svg     | https://example.com/images/logo.svg     | Company Logo        | Header   | logo       |
+```
+
+## Output Artifacts
+
+All output goes to the specified output directory (default `docs/clone/`):
+
+```
+docs/clone/
+├── screenshots/
+│   ├── desktop/
+│   │   ├── full-page.png
+│   │   ├── section-01-hero.png
+│   │   ├── section-02-features.png
+│   │   └── ...
+│   ├── tablet/
+│   │   └── full-page.png
+│   └── mobile/
+│       ├── full-page.png
+│       ├── section-01-hero.png
+│       └── ...
+├── content/
+│   └── <page-name>.md
+├── design-tokens.md
+├── section-reference.md
+└── media-map.md
+```
+
+## Cleanup
+
+```bash
+playwright-cli close -s=extract
+```
+
+## Standalone Usage
+
+This skill can be used independently for design research — extracting a site's
+design system without intending to clone it. Useful for competitive analysis,
+client site audits, or extracting tokens from an existing site to match in new
+components.
+
+## Usage as Sub-Agent (via nebula-clone-page)
+
+When spawned by the `nebula-clone-page` orchestrator, the orchestrator provides
+the URL and output directory. This skill runs the full extraction workflow and
+the orchestrator reads the output artifacts for the next phase.

--- a/.agents/skills/nebula-design-extraction/references/content-example.md
+++ b/.agents/skills/nebula-design-extraction/references/content-example.md
@@ -1,0 +1,50 @@
+# Content File — Example Format
+
+Output to `content/<page-name>.md`. Each section includes metadata comments for
+Context, Layout, and Screenshot paths. Text is extracted
+character-for-character.
+
+```markdown
+# <Page Title>
+
+## Section 1: Hero
+
+<!-- Context: Full-width hero with dark background overlay -->
+<!-- Layout: Centered text, CTA button below -->
+<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
+
+### Heading
+
+Welcome to Our Company
+
+### Subheading
+
+Building the future, one component at a time.
+
+### CTA Button
+
+Get Started → /contact
+
+### Background Image
+
+hero-bg.jpg (https://example.com/images/hero-bg.jpg)
+
+---
+
+## Section 2: Features
+
+<!-- Context: 3-column card grid on light background -->
+<!-- Layout: Grid, 3 cols desktop, stacked mobile -->
+<!-- Screenshot: screenshots/desktop/section-02-features.png -->
+
+### Card 1
+
+**Title:** Fast Development **Body:** Build components quickly with our modern
+toolchain. **Image:** /images/fast-dev.jpg (alt: Developer working on laptop)
+
+### Card 2
+
+**Title:** Responsive Design **Body:** Every component works perfectly on all
+screen sizes. **Image:** /images/responsive.jpg (alt: Devices showing responsive
+layout)
+```

--- a/.agents/skills/nebula-design-extraction/references/css-extraction-commands.md
+++ b/.agents/skills/nebula-design-extraction/references/css-extraction-commands.md
@@ -1,0 +1,45 @@
+# CSS Extraction Commands
+
+Use `playwright-cli eval` to extract computed styles from the page context.
+Repeat each block at mobile viewport (375px) to capture responsive changes.
+
+## Colors
+
+```bash
+playwright-cli eval "getComputedStyle(document.querySelector('.hero')).backgroundColor" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.hero')).color" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).color" -s=extract
+```
+
+## Typography
+
+```bash
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontFamily" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontSize" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontWeight" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).lineHeight" -s=extract
+```
+
+## Spacing
+
+```bash
+playwright-cli eval "getComputedStyle(document.querySelector('section')).padding" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.container')).maxWidth" -s=extract
+```
+
+## Effects
+
+```bash
+playwright-cli eval "getComputedStyle(document.querySelector('.card')).boxShadow" -s=extract
+playwright-cli eval "getComputedStyle(document.querySelector('.card')).borderRadius" -s=extract
+```
+
+## Responsive Workflow
+
+```bash
+# Extract at desktop first (1280px), then resize and repeat
+playwright-cli resize 375 812 -s=extract
+# Re-run the above eval commands at mobile viewport
+# Reset when done
+playwright-cli resize 1280 900 -s=extract
+```

--- a/.agents/skills/nebula-design-extraction/references/design-tokens-example.md
+++ b/.agents/skills/nebula-design-extraction/references/design-tokens-example.md
@@ -1,0 +1,38 @@
+# Design Tokens — Example Format
+
+## Colors
+
+| Token      | Value   | Usage                    |
+| ---------- | ------- | ------------------------ |
+| primary    | #1a365d | Headings, nav background |
+| accent     | #e53e3e | CTA buttons, highlights  |
+| background | #f7fafc | Page background          |
+| text       | #2d3748 | Body text                |
+| text-light | #718096 | Captions, secondary text |
+
+## Typography
+
+| Element | Font             | Size (desktop) | Size (mobile) | Weight | Line Height |
+| ------- | ---------------- | -------------- | ------------- | ------ | ----------- |
+| h1      | Playfair Display | 3rem           | 2rem          | 700    | 1.2         |
+| h2      | Playfair Display | 2.25rem        | 1.5rem        | 600    | 1.3         |
+| body    | Inter            | 1rem           | 1rem          | 400    | 1.6         |
+| small   | Inter            | 0.875rem       | 0.875rem      | 400    | 1.5         |
+
+## Spacing
+
+| Context             | Desktop  | Mobile    |
+| ------------------- | -------- | --------- |
+| Section padding     | 80px 0   | 40px 16px |
+| Container max-width | 1200px   | 100%      |
+| Card gap            | 24px     | 16px      |
+| Standard unit       | 8px grid | 8px grid  |
+
+## Effects
+
+| Effect                  | Value                     |
+| ----------------------- | ------------------------- |
+| Card shadow             | 0 4px 6px rgba(0,0,0,0.1) |
+| Border radius (cards)   | 12px                      |
+| Border radius (buttons) | 8px                       |
+| Hover transition        | 200ms ease-in-out         |

--- a/.agents/skills/nebula-design-extraction/references/output-formats.md
+++ b/.agents/skills/nebula-design-extraction/references/output-formats.md
@@ -1,0 +1,30 @@
+# Output Formats — section-reference.md and media-map.md
+
+## section-reference.md
+
+Map each section to its screenshots, content, and structural notes.
+
+```markdown
+# Section Reference
+
+| #   | Section  | Type        | Desktop Screenshot      | Mobile Screenshot       | Component Hint        |
+| --- | -------- | ----------- | ----------------------- | ----------------------- | --------------------- |
+| 1   | Hero     | Hero banner | section-01-hero.png     | section-01-hero.png     | hero                  |
+| 2   | Features | Card grid   | section-02-features.png | section-02-features.png | card_container + card |
+| 3   | About    | Two-column  | section-03-about.png    | section-03-about.png    | two_column_text       |
+| 4   | CTA      | Banner      | section-04-cta.png      | section-04-cta.png      | section + button      |
+```
+
+## media-map.md
+
+List all images, videos, and media assets found on the page.
+
+```markdown
+# Media Map
+
+| #   | Filename     | Source URL                              | Alt Text            | Section  | Type       |
+| --- | ------------ | --------------------------------------- | ------------------- | -------- | ---------- |
+| 1   | hero-bg.jpg  | https://example.com/images/hero-bg.jpg  | Mountain landscape  | Hero     | background |
+| 2   | fast-dev.jpg | https://example.com/images/fast-dev.jpg | Developer on laptop | Features | content    |
+| 3   | logo.svg     | https://example.com/images/logo.svg     | Company Logo        | Header   | logo       |
+```

--- a/.agents/skills/nebula-docs-explorer/SKILL.md
+++ b/.agents/skills/nebula-docs-explorer/SKILL.md
@@ -1,31 +1,23 @@
 ---
 name: nebula-docs-explorer
 description:
-  Search and fetch Canvas and Drupal CMS documentation pages. Takes a query
-  describing what you need to know (e.g., "code components", "page regions",
-  "known issues", "data fetching") and returns the full content of matching
-  documentation pages. Use whenever you need to understand how Canvas or Drupal
-  CMS works, verify platform behavior, check for limitations, or find
-  configuration options.
+  Fetch Canvas and Drupal CMS documentation on demand. Use when you need to
+  verify platform behavior, check for limitations, understand Canvas APIs, or
+  troubleshoot component issues — even if you think you know the answer, as docs
+  may have changed.
+compatibility: Requires internet access to fetch documentation pages.
 ---
 
 # Canvas & Drupal CMS Documentation Explorer
 
-Fetch and return official Canvas and Drupal CMS documentation relevant to a
-query. This skill searches a curated URL catalog, identifies the most relevant
-pages, fetches their full content, and returns it.
+Fetch official Canvas and Drupal CMS documentation relevant to a query. Search a
+curated URL catalog, identify the most relevant pages, fetch their full content,
+and return it.
 
 ## Arguments
 
-- `$1` — **Query** (required). A natural language description of what you need
-  to know. Examples:
-  - `"known issues and limitations"`
-  - `"code components props slots"`
-  - `"data fetching SWR JsonApiClient"`
-  - `"page regions configuration"`
-  - `"creating custom components"`
-  - `"packages FormattedText cn"`
-  - `"JSON:API write mode"`
+`$1` — **Query** (required). Natural language description of what you need to
+know, e.g. `"code components props slots"` or `"data fetching JsonApiClient"`.
 
 ## Execution
 
@@ -40,13 +32,12 @@ by:
 - Always include the Known Issues inline content (below) if the query relates to
   components, Tailwind, Canvas, or troubleshooting
 
-Be generous with matching — it's better to fetch an extra page than miss a
-relevant one.
+Be generous — better to fetch an extra page than miss a relevant one.
 
 ### Step 2: Fetch matched pages
 
 For each matched URL, use `WebFetch` to retrieve the page content. Fetch pages
-in parallel where possible for speed.
+in parallel where possible.
 
 Use this prompt for each fetch:
 
@@ -108,9 +99,8 @@ remaining pages.
 
 ## Critical Known Issues (Inline — Always Available)
 
-These are known issues that should be referenced WITHOUT needing to fetch the
-docs page. Return these inline whenever the query relates to components,
-Tailwind, Canvas, or troubleshooting:
+Return these inline whenever the query relates to components, Tailwind, Canvas,
+or troubleshooting — no fetch needed:
 
 1. **Never remove components via the Component Library UI** — triggers an error
    that can break the site. Use the Code component panel instead.

--- a/.agents/skills/nebula-docs-explorer/SKILL.md
+++ b/.agents/skills/nebula-docs-explorer/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: nebula-docs-explorer
+description:
+  Search and fetch Canvas and Drupal CMS documentation pages. Takes a query
+  describing what you need to know (e.g., "code components", "page regions",
+  "known issues", "data fetching") and returns the full content of matching
+  documentation pages. Use whenever you need to understand how Canvas or Drupal
+  CMS works, verify platform behavior, check for limitations, or find
+  configuration options.
+---
+
+# Canvas & Drupal CMS Documentation Explorer
+
+Fetch and return official Canvas and Drupal CMS documentation relevant to a
+query. This skill searches a curated URL catalog, identifies the most relevant
+pages, fetches their full content, and returns it.
+
+## Arguments
+
+- `$1` — **Query** (required). A natural language description of what you need
+  to know. Examples:
+  - `"known issues and limitations"`
+  - `"code components props slots"`
+  - `"data fetching SWR JsonApiClient"`
+  - `"page regions configuration"`
+  - `"creating custom components"`
+  - `"packages FormattedText cn"`
+  - `"JSON:API write mode"`
+
+## Execution
+
+### Step 1: Match URLs to the query
+
+From the URL catalog below, identify **all pages relevant** to the query. Match
+by:
+
+- URL path segments (e.g., query "data fetching" matches the data-fetching URL)
+- Semantic relevance (e.g., query "component creation" matches code-components,
+  packages, and getting-started)
+- Always include the Known Issues inline content (below) if the query relates to
+  components, Tailwind, Canvas, or troubleshooting
+
+Be generous with matching — it's better to fetch an extra page than miss a
+relevant one.
+
+### Step 2: Fetch matched pages
+
+For each matched URL, use `WebFetch` to retrieve the page content. Fetch pages
+in parallel where possible for speed.
+
+Use this prompt for each fetch:
+
+> "Extract the COMPLETE content of this page. Return all text, code examples,
+> tables, steps, warnings, and notes. Do not summarize — return everything."
+
+### Step 3: Return results
+
+Return all fetched content organized by page, with clear headers:
+
+```
+## <Page Title> — <URL>
+
+<full page content>
+
+---
+
+## <Next Page Title> — <URL>
+
+<full page content>
+```
+
+If a page fails to load (404, 503, timeout), note the failure and continue with
+remaining pages.
+
+## URL Catalog
+
+### Canvas Official Documentation
+
+| Topic                                                   | URL                                                                            |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Canvas Overview                                         | `https://project.pages.drupalcode.org/canvas/`                                 |
+| Code Components                                         | `https://project.pages.drupalcode.org/canvas/code-components/`                 |
+| Getting Started                                         | `https://project.pages.drupalcode.org/canvas/code-components/getting-started/` |
+| Component Definition                                    | `https://project.pages.drupalcode.org/canvas/code-components/definition/`      |
+| Component Props                                         | `https://project.pages.drupalcode.org/canvas/code-components/props/`           |
+| Component Slots                                         | `https://project.pages.drupalcode.org/canvas/code-components/slots/`           |
+| Packages (FormattedText, cn, CVA, SWR)                  | `https://project.pages.drupalcode.org/canvas/code-components/packages/`        |
+| Data Fetching (getPageData, getSiteData, JsonApiClient) | `https://project.pages.drupalcode.org/canvas/code-components/data-fetching/`   |
+| Styling                                                 | `https://project.pages.drupalcode.org/canvas/code-components/styling/`         |
+| Upload & Deploy                                         | `https://project.pages.drupalcode.org/canvas/code-components/upload/`          |
+| Canvas CLI                                              | `https://project.pages.drupalcode.org/canvas/code-components/cli/`             |
+| Page Regions                                            | `https://project.pages.drupalcode.org/canvas/page-regions/`                    |
+| Known Issues                                            | `https://project.pages.drupalcode.org/canvas/known-issues/`                    |
+
+### Drupal CMS Documentation
+
+| Topic                           | URL                                                      |
+| ------------------------------- | -------------------------------------------------------- |
+| Drupal CMS Overview             | `https://new.drupal.org/docs/drupal-cms`                 |
+| Getting Started with Drupal CMS | `https://new.drupal.org/docs/drupal-cms/getting-started` |
+
+### Drupal Core Reference
+
+| Topic           | URL                                                                               |
+| --------------- | --------------------------------------------------------------------------------- |
+| JSON:API Module | `https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module` |
+| Menu System     | `https://www.drupal.org/docs/drupal-apis/menu-api`                                |
+
+## Critical Known Issues (Inline — Always Available)
+
+These are known issues that should be referenced WITHOUT needing to fetch the
+docs page. Return these inline whenever the query relates to components,
+Tailwind, Canvas, or troubleshooting:
+
+1. **Never remove components via the Component Library UI** — triggers an error
+   that can break the site. Use the Code component panel instead.
+2. **Tailwind directives** (`@apply`, `@layer`, etc.) work in `global.css` only
+   — NOT in component-specific CSS files.
+3. **Tailwind square bracket notation** does not work with `@apply`. Use
+   `@theme` variables instead.
+4. **Canvas page regions** may default to `status: false` on fresh installs.
+   Header/footer won't render until page regions are enabled.
+5. **JSON:API read-only mode** — Drupal may default to read-only. If write
+   operations return 405, enable writes in Drupal admin or via drush.
+6. **Media image field name** — field name may vary between Drupal distributions
+   (`field_media_image` vs `media_image`). Check the actual field name on the
+   target site.
+7. **Component JS crashes** — unguarded null access in a component will crash
+   the page renderer. Always guard optional props with `?.` and `&&`.

--- a/.agents/skills/nebula-figma-extraction/SKILL.md
+++ b/.agents/skills/nebula-figma-extraction/SKILL.md
@@ -1,250 +1,103 @@
 ---
 name: nebula-figma-extraction
 description:
-  Extract design tokens, frame screenshots, verbatim content, and style
-  definitions from a Figma file URL. Uses the Figma REST API for heavy
-  extraction and Figma MCP for light discovery. Produces the same artifact
-  format as nebula-design-extraction (design-tokens.md, content files,
-  screenshots, section reference). Use when cloning a Figma design into Canvas
-  components.
+  Extract design tokens, frame screenshots, and verbatim content from a Figma
+  file. Use when cloning a Figma design into Canvas components. Uses Figma REST
+  API for heavy extraction, MCP for light discovery.
+compatibility:
+  Requires FIGMA_TOKEN environment variable. Figma MCP optional for discovery.
 ---
 
 # Design Extraction from Figma
 
-Extract structured design data from a Figma file. This skill captures frame
-exports, design tokens from variables/styles, verbatim text content, and section
-structure — the same artifacts as `nebula-design-extraction` but sourced from
-Figma instead of a live site.
-
-## Prerequisites
-
-- **Figma access token** — set as `FIGMA_TOKEN` environment variable. Get one at
-  https://www.figma.com/developers/api#access-tokens
-- **Figma file URL** — the page or frame to extract from
+> **Content fidelity rule: ALL text must be extracted character-for-character
+> from Figma text nodes. NEVER rephrase, summarize, correct typos, or generate
+> text. If a text node cannot be read, mark it as `[UNREADABLE]`.**
 
 ## Arguments
 
-- `$1` — **Figma URL** (required). The file/frame to extract from.
-- `$2` — **Output directory** (optional). Defaults to `docs/clone/`.
-
-## Content Fidelity Rule
-
-> **ALL text must be extracted character-for-character from Figma text nodes.
-> NEVER rephrase, summarize, correct typos, or generate text. If a text node
-> cannot be read, mark it as `[UNREADABLE]`.**
-
-## Preflight Checks
-
-Before extraction, verify:
-
-```bash
-# Check token exists
-test -n "$FIGMA_TOKEN" || echo "Set FIGMA_TOKEN environment variable"
-
-# Test API access
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" https://api.figma.com/v1/me
-```
-
-## Figma URL Parsing
-
-Extract `fileKey` and `nodeId` from the URL:
-
-```
-figma.com/design/:fileKey/:fileName?node-id=:nodeId
-  → fileKey, nodeId (convert "-" to ":" in nodeId for API calls)
-
-figma.com/design/:fileKey/branch/:branchKey/:fileName
-  → use branchKey as fileKey
-
-figma.com/make/:makeFileKey/:makeFileName
-  → use makeFileKey
-```
+- `$1` -- **Figma URL** (required). The file/frame to extract from.
+- `$2` -- **Output directory** (optional). Defaults to `docs/clone/`.
 
 ## Two-Tool Strategy
 
-### Figma MCP (light usage — initial discovery)
+**Figma MCP** -- light usage for initial discovery only (1-2 calls):
 
-Use for orientation (1-2 calls, stays within rate limits):
+- `get_metadata(fileKey)` -- understand file structure, find pages and frames
+- `get_screenshot(fileKey, nodeId)` -- quick preview of a specific node
 
-- `get_metadata(fileKey)` — understand file structure, find pages and frames
-- `get_screenshot(fileKey, nodeId)` — quick preview of a specific node
+**Figma REST API** -- all intensive extraction work. See
+[references/figma-api-commands.md](references/figma-api-commands.md) for full
+curl examples. The REST API avoids MCP rate limits and supports batch
+operations.
 
-### Figma REST API (heavy usage — actual extraction)
+## Figma URL Parsing
 
-Use for all intensive extraction work:
+Extract `fileKey` and `nodeId` from the URL. Convert `-` to `:` in nodeId for
+API calls.
 
-```bash
-# Full file structure
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY"
+```
+figma.com/design/:fileKey/:fileName?node-id=:nodeId
+  -> fileKey, nodeId (convert "-" to ":" for API)
 
-# Specific node trees (with properties, layout, styles)
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/nodes?ids=$NODE_IDS"
+figma.com/design/:fileKey/branch/:branchKey/:fileName
+  -> use branchKey as fileKey
 
-# Export frames as PNG at 2x scale
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/images/$FILE_KEY?ids=$NODE_IDS&scale=2&format=png"
-# Returns: { "images": { "nodeId": "https://s3-url.png" } }
-
-# Published styles (colors, text, effects, grids)
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/styles"
-
-# Local variables (design tokens)
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/variables/local"
+figma.com/make/:makeFileKey/:makeFileName
+  -> use makeFileKey
 ```
 
-### Rate Limit Handling
+## Rate Limit Handling
 
-- Pace requests: max 2 per second to Figma REST API
+- Max 2 requests per second to Figma REST API
 - On 429 response: wait for `Retry-After` header duration
 - Batch node IDs in image export requests (up to 50 per call)
 
 ## Workflow
 
-### Step 1: Discover file structure
+- [ ] Parse Figma URL -- extract fileKey and nodeId
+- [ ] Preflight: verify FIGMA_TOKEN and API access
+- [ ] Discover file structure (Figma MCP `get_metadata`)
+- [ ] Extract variables and styles (REST API)
+- [ ] Export frames as PNG screenshots at 2x (REST API)
+- [ ] Extract node tree for content and structure (REST API)
+- [ ] Walk node tree: TEXT nodes for verbatim content, image fills for media,
+      auto-layout for responsive hints, component instances for structure
+- [ ] Generate `content/<page-name>.md` with verbatim text grouped by section
+- [ ] Generate `design-tokens.md`, `section-reference.md`, `media-map.md`,
+      `figma-reference.md`
+- [ ] Check for mobile frames -- export to `screenshots/mobile/` if present,
+      note absence in section-reference.md if not
 
-Use Figma MCP `get_metadata` or REST API to understand the file:
+See [references/figma-tokens-example.md](references/figma-tokens-example.md) for
+design token mapping and content file format examples.
 
-- Which pages exist
-- Which frames are on the target page
-- If a `nodeId` was in the URL, scope to that node
+## Mobile Frame Considerations
 
-### Step 2: Extract design variables and styles
-
-```bash
-# Local variables (color primitives, semantic colors, spacing)
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/variables/local"
-
-# Published styles (text styles, color styles, effect styles)
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/styles"
-```
-
-Map Figma variables to design tokens:
-
-```markdown
-## Colors (from variable collection "Colors")
-
-| Token         | Value   | Figma Variable         |
-| ------------- | ------- | ---------------------- |
-| primary       | #1B4D3E | Colors/Primary/Default |
-| primary-light | #2A7A5E | Colors/Primary/Light   |
-| accent        | #F5A623 | Colors/Accent/Default  |
-
-## Typography (from text styles)
-
-| Style        | Font             | Size | Weight  | Line Height |
-| ------------ | ---------------- | ---- | ------- | ----------- |
-| Heading/H1   | Playfair Display | 56   | Bold    | 64          |
-| Body/Regular | Inter            | 18   | Regular | 28          |
-```
-
-### Step 3: Export frames as screenshots
-
-```bash
-# Get temporary download URLs for frame exports
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/images/$FILE_KEY?ids=$SECTION_NODE_IDS&scale=2&format=png"
-
-# Download each PNG
-curl -o screenshots/desktop/section-01-hero.png "<s3-url>"
-curl -o screenshots/desktop/section-02-features.png "<s3-url>"
-```
-
-Export the full page frame and each major section frame.
-
-### Step 4: Extract node tree for structure and content
-
-```bash
-curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
-  "https://api.figma.com/v1/files/$FILE_KEY/nodes?ids=$NODE_IDS"
-```
-
-Walk the node tree and extract:
-
-- **TEXT nodes** → verbatim text content, grouped by section/frame
-- **Image fills** → media URLs for media-map.md
-- **Auto-layout settings** → responsive layout hints (direction, gap, padding)
-- **Component instances** → what Figma components are used
-
-### Step 5: Generate content file
-
-Output `content/<page-name>.md` in the same format as
-`nebula-design-extraction`:
-
-```markdown
-# <Page Title>
-
-## Section 1: Hero
-
-<!-- Context: Full-width hero frame -->
-<!-- Layout: Auto-layout vertical, center-aligned -->
-<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
-
-### Heading
-
-Welcome to Our Platform
-
-### Body
-
-The text exactly as it appears in the Figma text node.
-```
-
-### Step 6: Generate remaining artifacts
-
-Produce the same output structure as `nebula-design-extraction`:
-
-- `design-tokens.md` — from Figma variables and styles
-- `section-reference.md` — frame-to-screenshot mapping
-- `media-map.md` — image fills and exported assets
-- `figma-reference.md` — Figma-specific extras: node IDs, component instance
-  names, Code Connect snippets (if available)
-
-### Step 7: Mobile considerations
-
-Check if mobile frames exist in the file:
-
-- **If yes:** Export those too, save to `screenshots/mobile/`
-- **If no:** Note in section-reference.md that mobile designs are not available.
-  The QA skill will verify responsive behavior against best judgment rather than
-  a mobile reference.
+If mobile frames exist in the file, export them to `screenshots/mobile/`. If no
+mobile frames exist, note this in section-reference.md so downstream skills know
+to verify responsive behavior against best judgment rather than a mobile
+reference.
 
 ## Output Artifacts
 
 ```
 docs/clone/
-├── screenshots/
-│   ├── desktop/
-│   │   ├── full-page.png
-│   │   ├── section-01-hero.png
-│   │   └── ...
-│   └── mobile/              (if mobile frames exist)
-│       └── ...
-├── content/
-│   └── <page-name>.md
-├── design-tokens.md
-├── section-reference.md
-├── media-map.md
-└── figma-reference.md       (node IDs, component instances, Code Connect)
+  screenshots/
+    desktop/
+      full-page.png           -- full page export
+      section-01-hero.png     -- per-section exports
+    mobile/                   -- if mobile frames exist
+  content/
+    <page-name>.md            -- verbatim text grouped by section
+  design-tokens.md            -- Figma variables and styles as tokens
+  section-reference.md        -- frame-to-screenshot mapping
+  media-map.md                -- image fills and exported assets
+  figma-reference.md          -- node IDs, component instances, Code Connect
 ```
 
 ## Relationship to implement-design
 
-|            | implement-design                | nebula-figma-extraction                       |
-| ---------- | ------------------------------- | --------------------------------------------- |
-| Purpose    | Translate one component to code | Extract all design data from a page           |
-| Output     | Component code                  | Artifact files (tokens, content, screenshots) |
-| Figma tool | Figma MCP only                  | REST API (heavy) + MCP (light)                |
-| Scope      | Single node                     | Full page with all sections                   |
-
-They're complementary. This skill extracts raw materials. `implement-design` can
-be used during component building to get Code Connect context for individual
-nodes.
-
-## Cleanup
-
-No browser sessions to close (Figma extraction uses REST API, not browser).
+This skill extracts raw design materials (tokens, content, screenshots) from a
+full page. `implement-design` translates a single Figma node into component code
+using MCP. They are complementary: extract first, then implement per component.

--- a/.agents/skills/nebula-figma-extraction/SKILL.md
+++ b/.agents/skills/nebula-figma-extraction/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: nebula-figma-extraction
+description:
+  Extract design tokens, frame screenshots, verbatim content, and style
+  definitions from a Figma file URL. Uses the Figma REST API for heavy
+  extraction and Figma MCP for light discovery. Produces the same artifact
+  format as nebula-design-extraction (design-tokens.md, content files,
+  screenshots, section reference). Use when cloning a Figma design into Canvas
+  components.
+---
+
+# Design Extraction from Figma
+
+Extract structured design data from a Figma file. This skill captures frame
+exports, design tokens from variables/styles, verbatim text content, and section
+structure — the same artifacts as `nebula-design-extraction` but sourced from
+Figma instead of a live site.
+
+## Prerequisites
+
+- **Figma access token** — set as `FIGMA_TOKEN` environment variable. Get one at
+  https://www.figma.com/developers/api#access-tokens
+- **Figma file URL** — the page or frame to extract from
+
+## Arguments
+
+- `$1` — **Figma URL** (required). The file/frame to extract from.
+- `$2` — **Output directory** (optional). Defaults to `docs/clone/`.
+
+## Content Fidelity Rule
+
+> **ALL text must be extracted character-for-character from Figma text nodes.
+> NEVER rephrase, summarize, correct typos, or generate text. If a text node
+> cannot be read, mark it as `[UNREADABLE]`.**
+
+## Preflight Checks
+
+Before extraction, verify:
+
+```bash
+# Check token exists
+test -n "$FIGMA_TOKEN" || echo "Set FIGMA_TOKEN environment variable"
+
+# Test API access
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" https://api.figma.com/v1/me
+```
+
+## Figma URL Parsing
+
+Extract `fileKey` and `nodeId` from the URL:
+
+```
+figma.com/design/:fileKey/:fileName?node-id=:nodeId
+  → fileKey, nodeId (convert "-" to ":" in nodeId for API calls)
+
+figma.com/design/:fileKey/branch/:branchKey/:fileName
+  → use branchKey as fileKey
+
+figma.com/make/:makeFileKey/:makeFileName
+  → use makeFileKey
+```
+
+## Two-Tool Strategy
+
+### Figma MCP (light usage — initial discovery)
+
+Use for orientation (1-2 calls, stays within rate limits):
+
+- `get_metadata(fileKey)` — understand file structure, find pages and frames
+- `get_screenshot(fileKey, nodeId)` — quick preview of a specific node
+
+### Figma REST API (heavy usage — actual extraction)
+
+Use for all intensive extraction work:
+
+```bash
+# Full file structure
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY"
+
+# Specific node trees (with properties, layout, styles)
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/nodes?ids=$NODE_IDS"
+
+# Export frames as PNG at 2x scale
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/images/$FILE_KEY?ids=$NODE_IDS&scale=2&format=png"
+# Returns: { "images": { "nodeId": "https://s3-url.png" } }
+
+# Published styles (colors, text, effects, grids)
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/styles"
+
+# Local variables (design tokens)
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/variables/local"
+```
+
+### Rate Limit Handling
+
+- Pace requests: max 2 per second to Figma REST API
+- On 429 response: wait for `Retry-After` header duration
+- Batch node IDs in image export requests (up to 50 per call)
+
+## Workflow
+
+### Step 1: Discover file structure
+
+Use Figma MCP `get_metadata` or REST API to understand the file:
+
+- Which pages exist
+- Which frames are on the target page
+- If a `nodeId` was in the URL, scope to that node
+
+### Step 2: Extract design variables and styles
+
+```bash
+# Local variables (color primitives, semantic colors, spacing)
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/variables/local"
+
+# Published styles (text styles, color styles, effect styles)
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/styles"
+```
+
+Map Figma variables to design tokens:
+
+```markdown
+## Colors (from variable collection "Colors")
+
+| Token         | Value   | Figma Variable         |
+| ------------- | ------- | ---------------------- |
+| primary       | #1B4D3E | Colors/Primary/Default |
+| primary-light | #2A7A5E | Colors/Primary/Light   |
+| accent        | #F5A623 | Colors/Accent/Default  |
+
+## Typography (from text styles)
+
+| Style        | Font             | Size | Weight  | Line Height |
+| ------------ | ---------------- | ---- | ------- | ----------- |
+| Heading/H1   | Playfair Display | 56   | Bold    | 64          |
+| Body/Regular | Inter            | 18   | Regular | 28          |
+```
+
+### Step 3: Export frames as screenshots
+
+```bash
+# Get temporary download URLs for frame exports
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/images/$FILE_KEY?ids=$SECTION_NODE_IDS&scale=2&format=png"
+
+# Download each PNG
+curl -o screenshots/desktop/section-01-hero.png "<s3-url>"
+curl -o screenshots/desktop/section-02-features.png "<s3-url>"
+```
+
+Export the full page frame and each major section frame.
+
+### Step 4: Extract node tree for structure and content
+
+```bash
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/nodes?ids=$NODE_IDS"
+```
+
+Walk the node tree and extract:
+
+- **TEXT nodes** → verbatim text content, grouped by section/frame
+- **Image fills** → media URLs for media-map.md
+- **Auto-layout settings** → responsive layout hints (direction, gap, padding)
+- **Component instances** → what Figma components are used
+
+### Step 5: Generate content file
+
+Output `content/<page-name>.md` in the same format as
+`nebula-design-extraction`:
+
+```markdown
+# <Page Title>
+
+## Section 1: Hero
+
+<!-- Context: Full-width hero frame -->
+<!-- Layout: Auto-layout vertical, center-aligned -->
+<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
+
+### Heading
+
+Welcome to Our Platform
+
+### Body
+
+The text exactly as it appears in the Figma text node.
+```
+
+### Step 6: Generate remaining artifacts
+
+Produce the same output structure as `nebula-design-extraction`:
+
+- `design-tokens.md` — from Figma variables and styles
+- `section-reference.md` — frame-to-screenshot mapping
+- `media-map.md` — image fills and exported assets
+- `figma-reference.md` — Figma-specific extras: node IDs, component instance
+  names, Code Connect snippets (if available)
+
+### Step 7: Mobile considerations
+
+Check if mobile frames exist in the file:
+
+- **If yes:** Export those too, save to `screenshots/mobile/`
+- **If no:** Note in section-reference.md that mobile designs are not available.
+  The QA skill will verify responsive behavior against best judgment rather than
+  a mobile reference.
+
+## Output Artifacts
+
+```
+docs/clone/
+├── screenshots/
+│   ├── desktop/
+│   │   ├── full-page.png
+│   │   ├── section-01-hero.png
+│   │   └── ...
+│   └── mobile/              (if mobile frames exist)
+│       └── ...
+├── content/
+│   └── <page-name>.md
+├── design-tokens.md
+├── section-reference.md
+├── media-map.md
+└── figma-reference.md       (node IDs, component instances, Code Connect)
+```
+
+## Relationship to implement-design
+
+|            | implement-design                | nebula-figma-extraction                       |
+| ---------- | ------------------------------- | --------------------------------------------- |
+| Purpose    | Translate one component to code | Extract all design data from a page           |
+| Output     | Component code                  | Artifact files (tokens, content, screenshots) |
+| Figma tool | Figma MCP only                  | REST API (heavy) + MCP (light)                |
+| Scope      | Single node                     | Full page with all sections                   |
+
+They're complementary. This skill extracts raw materials. `implement-design` can
+be used during component building to get Code Connect context for individual
+nodes.
+
+## Cleanup
+
+No browser sessions to close (Figma extraction uses REST API, not browser).

--- a/.agents/skills/nebula-figma-extraction/references/figma-api-commands.md
+++ b/.agents/skills/nebula-figma-extraction/references/figma-api-commands.md
@@ -1,0 +1,64 @@
+# Figma REST API Commands
+
+All commands require `FIGMA_TOKEN` environment variable.
+
+## File Structure
+
+```bash
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY"
+```
+
+## Specific Node Trees
+
+Retrieve properties, layout, and styles for specific nodes:
+
+```bash
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/nodes?ids=$NODE_IDS"
+```
+
+## Export Frames as PNG
+
+Export at 2x scale. Returns temporary S3 download URLs.
+
+```bash
+# Get download URLs
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/images/$FILE_KEY?ids=$NODE_IDS&scale=2&format=png"
+# Response: { "images": { "nodeId": "https://s3-url.png" } }
+
+# Download each PNG
+curl -o screenshots/desktop/section-01-hero.png "<s3-url>"
+curl -o screenshots/desktop/section-02-features.png "<s3-url>"
+```
+
+Batch node IDs in image export requests (up to 50 per call).
+
+## Published Styles
+
+Colors, text styles, effects, grids:
+
+```bash
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/styles"
+```
+
+## Local Variables (Design Tokens)
+
+Color primitives, semantic colors, spacing:
+
+```bash
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" \
+  "https://api.figma.com/v1/files/$FILE_KEY/variables/local"
+```
+
+## Preflight Check
+
+```bash
+# Verify token exists
+test -n "$FIGMA_TOKEN" || echo "Set FIGMA_TOKEN environment variable"
+
+# Test API access
+curl -sH "X-Figma-Token: $FIGMA_TOKEN" https://api.figma.com/v1/me
+```

--- a/.agents/skills/nebula-figma-extraction/references/figma-tokens-example.md
+++ b/.agents/skills/nebula-figma-extraction/references/figma-tokens-example.md
@@ -1,0 +1,40 @@
+# Design Tokens Mapping Example
+
+Map Figma variables and styles to design-tokens.md format.
+
+## Colors (from variable collection "Colors")
+
+| Token         | Value   | Figma Variable         |
+| ------------- | ------- | ---------------------- |
+| primary       | #1B4D3E | Colors/Primary/Default |
+| primary-light | #2A7A5E | Colors/Primary/Light   |
+| accent        | #F5A623 | Colors/Accent/Default  |
+
+## Typography (from text styles)
+
+| Style        | Font             | Size | Weight  | Line Height |
+| ------------ | ---------------- | ---- | ------- | ----------- |
+| Heading/H1   | Playfair Display | 56   | Bold    | 64          |
+| Body/Regular | Inter            | 18   | Regular | 28          |
+
+## Content File Format
+
+Output `content/<page-name>.md`:
+
+```markdown
+# <Page Title>
+
+## Section 1: Hero
+
+<!-- Context: Full-width hero frame -->
+<!-- Layout: Auto-layout vertical, center-aligned -->
+<!-- Screenshot: screenshots/desktop/section-01-hero.png -->
+
+### Heading
+
+Welcome to Our Platform
+
+### Body
+
+The text exactly as it appears in the Figma text node.
+```

--- a/.agents/skills/nebula-frontend-design/LICENSE
+++ b/.agents/skills/nebula-frontend-design/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/nebula-frontend-design/SKILL.md
+++ b/.agents/skills/nebula-frontend-design/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: nebula-frontend-design
 description:
-  Create distinctive, production-grade frontend interfaces with high design
-  quality. Use when building components from scratch or adapting designs to
-  avoid generic AI aesthetics. Guides aesthetic decisions (WHAT and WHY) while
-  canvas-styling-conventions handles implementation (HOW).
+  Guide bold, distinctive design decisions for Canvas components. Use when
+  building components from scratch, when designs look generic, or when the user
+  wants creative direction beyond mechanical implementation. Covers typography,
+  color, motion, composition, and anti-patterns. Guides aesthetic decisions
+  (WHAT and WHY) while canvas-styling-conventions handles implementation (HOW).
 ---
 
 <!-- Attribution: Adapted from the frontend-design skill by Anthropic. -->
@@ -23,16 +24,15 @@ direction beyond mechanical implementation.
 
 Before coding, understand the context and commit to a BOLD aesthetic direction:
 
-- **Purpose**: What problem does this interface solve? Who uses it?
-- **Tone**: Pick a direction and commit to it: brutally minimal, maximalist
-  chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like,
-  editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
-  industrial/utilitarian. Use these for inspiration but design one that is true
-  to the aesthetic direction.
-- **Constraints**: Technical requirements (Canvas component contract, Tailwind
-  tokens, responsive behavior).
-- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing
-  someone will remember?
+- **Purpose**: What problem does this interface solve and who uses it?
+- **Tone**: Commit to a direction — brutally minimal, maximalist chaos,
+  retro-futuristic, organic, luxury, playful, editorial, brutalist, art deco,
+  soft/pastel, industrial. Use for inspiration but design true to the chosen
+  aesthetic.
+- **Constraints**: Canvas component contract, Tailwind tokens, responsive
+  behavior.
+- **Differentiation**: What makes this UNFORGETTABLE — the one thing someone
+  will remember?
 
 Choose a clear conceptual direction and execute it with precision. Bold
 maximalism and refined minimalism both work — the key is intentionality, not
@@ -107,13 +107,11 @@ design intent.
 
 NEVER use generic AI-generated aesthetics:
 
-- Overused font families (Inter, Roboto, Arial, system fonts as primary)
-- Cliched color schemes (particularly purple gradients on white backgrounds)
-- Predictable layouts and component patterns
-- Cookie-cutter design that lacks context-specific character
-- Perfectly symmetric, grid-aligned everything
-- Standard border-radius on everything
-- The same card layout every time
+- Overused fonts (Inter, Roboto, Arial, system fonts as primary display type)
+- Cliched purple-gradient-on-white color schemes
+- Predictable, perfectly symmetric, grid-aligned-everything layouts
+- Cookie-cutter card patterns with uniform border-radius
+- Designs that lack context-specific character
 
 Interpret creatively and make unexpected choices that feel genuinely designed
 for the context. No design should be the same. Vary between light and dark
@@ -121,14 +119,9 @@ themes, different fonts, different aesthetics.
 
 ## Relationship to Other Skills
 
-- **This skill** = WHAT and WHY (aesthetic decisions, design direction)
-- **`canvas-styling-conventions`** = HOW (Tailwind tokens, CVA patterns, `cn()`)
-- **`implement-design`** = Figma-to-code translation (1:1 fidelity to an
-  existing design)
-
-This skill is for when you're making design decisions. If you're implementing an
-existing Figma design, use `implement-design` instead. If you need to know how
-to write the CSS/Tailwind, load `canvas-styling-conventions`.
+**This skill** = WHAT and WHY (aesthetic decisions).
+**`canvas-styling-conventions`** = HOW (Tailwind tokens, CVA, `cn()`).
+**`implement-design`** = Figma-to-code (1:1 fidelity to an existing design).
 
 Match implementation complexity to the aesthetic vision. Maximalist designs need
 elaborate code with extensive animations and effects. Minimalist or refined

--- a/.agents/skills/nebula-frontend-design/SKILL.md
+++ b/.agents/skills/nebula-frontend-design/SKILL.md
@@ -3,9 +3,7 @@ name: nebula-frontend-design
 description:
   Guide bold, distinctive design decisions for Canvas components. Use when
   building components from scratch, when designs look generic, or when the user
-  wants creative direction beyond mechanical implementation. Covers typography,
-  color, motion, composition, and anti-patterns. Guides aesthetic decisions
-  (WHAT and WHY) while canvas-styling-conventions handles implementation (HOW).
+  wants creative direction beyond mechanical implementation.
 ---
 
 <!-- Attribution: Adapted from the frontend-design skill by Anthropic. -->

--- a/.agents/skills/nebula-frontend-design/SKILL.md
+++ b/.agents/skills/nebula-frontend-design/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: nebula-frontend-design
+description:
+  Create distinctive, production-grade frontend interfaces with high design
+  quality. Use when building components from scratch or adapting designs to
+  avoid generic AI aesthetics. Guides aesthetic decisions (WHAT and WHY) while
+  canvas-styling-conventions handles implementation (HOW).
+---
+
+<!-- Attribution: Adapted from the frontend-design skill by Anthropic. -->
+<!-- Original authors: Prithvi Rajasekaran, Alexander Bricken. -->
+<!-- Licensed under Apache License 2.0. See LICENSE in this directory. -->
+<!-- Modified: Added Canvas-specific adaptations for Nebula projects. -->
+
+# Frontend Design for Canvas Components
+
+This skill guides creation of distinctive, production-grade frontend interfaces
+that avoid generic "AI slop" aesthetics. Use it when building Canvas components
+from scratch, adapting a reference design, or when components need creative
+direction beyond mechanical implementation.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick a direction and commit to it: brutally minimal, maximalist
+  chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like,
+  editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel,
+  industrial/utilitarian. Use these for inspiration but design one that is true
+  to the aesthetic direction.
+- **Constraints**: Technical requirements (Canvas component contract, Tailwind
+  tokens, responsive behavior).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing
+  someone will remember?
+
+Choose a clear conceptual direction and execute it with precision. Bold
+maximalism and refined minimalism both work — the key is intentionality, not
+intensity.
+
+## Frontend Aesthetics Guidelines
+
+### Typography
+
+Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts
+like Arial and Inter; opt instead for distinctive choices that elevate the
+interface. Pair a distinctive display font with a refined body font.
+
+**Canvas implementation:** Define font tokens in `global.css` using the `@theme`
+block. Import fonts in `.storybook/preview-head.html` for Storybook and ensure
+they're available in the Canvas site's theme.
+
+```css
+/* global.css */
+@theme {
+  --font-display: "Clash Display", sans-serif;
+  --font-body: "Satoshi", sans-serif;
+}
+```
+
+### Color & Theme
+
+Commit to a cohesive aesthetic. Dominant colors with sharp accents outperform
+timid, evenly-distributed palettes.
+
+**Canvas implementation:** Define all colors as `@theme` tokens. Use CVA
+variants for color scheme props — never hardcode hex values in components.
+Reference `canvas-styling-conventions` for the CVA + `cn()` pattern.
+
+```css
+/* global.css */
+@theme {
+  --color-brand: #1a365d;
+  --color-accent: #e53e3e;
+  --color-surface: #f7fafc;
+}
+```
+
+### Motion
+
+Use animations for effects and micro-interactions. Prioritize CSS-only
+solutions. Focus on high-impact moments: one well-orchestrated page load with
+staggered reveals creates more delight than scattered micro-interactions. Use
+scroll-triggering and hover states that surprise.
+
+**Canvas consideration:** Components render server-side too. Ensure motion
+degrades gracefully — the component should look complete without animation, with
+animation enhancing the experience.
+
+### Spatial Composition
+
+Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements.
+Generous negative space OR controlled density.
+
+**Canvas implementation:** Spatial composition must work within Canvas Section
+and Grid components. Use slots for flexible composition rather than hardcoded
+layout structures.
+
+### Backgrounds & Visual Details
+
+Create atmosphere and depth rather than defaulting to solid colors. Apply
+gradient meshes, noise textures, geometric patterns, layered transparencies,
+dramatic shadows, decorative borders, and grain overlays where they serve the
+design intent.
+
+## What to Avoid
+
+NEVER use generic AI-generated aesthetics:
+
+- Overused font families (Inter, Roboto, Arial, system fonts as primary)
+- Cliched color schemes (particularly purple gradients on white backgrounds)
+- Predictable layouts and component patterns
+- Cookie-cutter design that lacks context-specific character
+- Perfectly symmetric, grid-aligned everything
+- Standard border-radius on everything
+- The same card layout every time
+
+Interpret creatively and make unexpected choices that feel genuinely designed
+for the context. No design should be the same. Vary between light and dark
+themes, different fonts, different aesthetics.
+
+## Relationship to Other Skills
+
+- **This skill** = WHAT and WHY (aesthetic decisions, design direction)
+- **`canvas-styling-conventions`** = HOW (Tailwind tokens, CVA patterns, `cn()`)
+- **`implement-design`** = Figma-to-code translation (1:1 fidelity to an
+  existing design)
+
+This skill is for when you're making design decisions. If you're implementing an
+existing Figma design, use `implement-design` instead. If you need to know how
+to write the CSS/Tailwind, load `canvas-styling-conventions`.
+
+Match implementation complexity to the aesthetic vision. Maximalist designs need
+elaborate code with extensive animations and effects. Minimalist or refined
+designs need restraint, precision, and careful attention to spacing, typography,
+and subtle details.

--- a/.agents/skills/nebula-scrape-url/SKILL.md
+++ b/.agents/skills/nebula-scrape-url/SKILL.md
@@ -2,57 +2,28 @@
 name: nebula-scrape-url
 description:
   Capture web page screenshots and HTML for design reference. Use when the user
-  provides a URL and asks to build, recreate, or implement a design. Supports
-  two modes — quick capture via scrape-page.js or interactive exploration via
-  Playwright CLI. Not for Figma, GitHub, or documentation URLs.
+  provides a URL and wants to build, recreate, or implement a design. Supports
+  quick capture and interactive browser exploration.
+compatibility: Requires @playwright/cli (included in Nebula).
 ---
 
 # Scraping URLs for design reference
 
-**This applies to web page URLs only.** Do not use this for:
+**Web page URLs only.** Do not use this for Figma URLs (use Figma MCP), GitHub
+URLs (read code directly), or documentation URLs (read/search as needed).
 
-- Figma URLs (use the Figma MCP instead)
-- GitHub URLs (read the code directly)
-- Documentation URLs (read or search as needed)
+## Default: Playwright CLI
 
-## Quick capture with scrape-page.js
+Use Playwright CLI for all browser automation -- capturing screenshots,
+extracting styles, comparing renders, navigating multi-page flows. Fall back to
+`scrape-page.js` only for CloudFlare-protected sites or quick one-shot captures
+where you need all three viewports in one command.
 
-For simple, one-shot captures of a page. Handles CloudFlare-protected sites
-automatically via visible browser mode.
+Run `playwright-cli --help` for the full command reference.
 
-```bash
-node scripts/scrape-page.js <url>
-```
-
-**Output** in `scraped/<timestamp>/`:
-
-- `screenshot-desktop.png` — 1280px width
-- `screenshot-tablet.png` — 768px width
-- `screenshot-mobile.png` — 375px width
-- `page.html` — complete HTML
-- `metadata.json` — page info
-
-**Options:**
+### Basic capture
 
 ```bash
-node scripts/scrape-page.js <url> --headless        # skip visible browser
-node scripts/scrape-page.js <url> --no-screenshots   # HTML only
-```
-
-Use this when you just need reference screenshots and HTML to start building.
-
-## Interactive exploration with Playwright CLI
-
-For multi-step workflows: navigating pages, extracting computed styles,
-comparing Storybook renders against references, filling forms, or any iterative
-browser work.
-
-Run `playwright-cli --help` for all available commands.
-
-### Basic capture workflow
-
-```bash
-# Open page and capture at multiple viewports
 playwright-cli open https://example.com
 playwright-cli screenshot --full-page
 playwright-cli resize 768 1024
@@ -62,63 +33,41 @@ playwright-cli screenshot --full-page
 playwright-cli close
 ```
 
-Screenshots are saved to `.playwright-cli/` with timestamps.
-
-### Page structure extraction
-
-```bash
-playwright-cli open https://example.com
-playwright-cli snapshot                    # accessibility tree as YAML
-playwright-cli eval "document.title"       # evaluate JS expressions
-playwright-cli close
-```
+Screenshots save to `.playwright-cli/` with timestamps.
 
 ### Section-level screenshots
 
 ```bash
 playwright-cli open https://example.com
-playwright-cli snapshot                    # find element refs
+playwright-cli snapshot                    # accessibility tree -- find element refs
 playwright-cli screenshot e5              # screenshot specific element by ref
 playwright-cli close
 ```
 
-### Extracting computed styles
-
-```bash
-playwright-cli open https://example.com
-playwright-cli eval "getComputedStyle(document.querySelector('.hero')).backgroundColor"
-playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontFamily"
-```
-
 ### Parallel sessions for comparison
 
-Use named sessions to have source and Storybook open simultaneously:
-
 ```bash
-# Source in one session
 playwright-cli -s=source open https://example.com
 playwright-cli -s=source screenshot --full-page
 
-# Storybook in another
 playwright-cli -s=storybook open http://localhost:6006/iframe.html?id=organisms-hero--default
 playwright-cli -s=storybook screenshot --full-page
 
-# Compare the screenshots visually
-# Clean up
 playwright-cli close-all
 ```
 
-## When to use which
+## Fallback: scrape-page.js
 
-| Need                                | Tool                                  |
-| ----------------------------------- | ------------------------------------- |
-| Quick reference screenshots         | `scrape-page.js`                      |
-| CloudFlare-protected sites          | `scrape-page.js` (built-in CF bypass) |
-| Interactive page exploration        | Playwright CLI                        |
-| Extract CSS / computed styles       | Playwright CLI (`eval`)               |
-| Visual QA comparison loops          | Playwright CLI (named sessions)       |
-| Multi-step workflows (login, forms) | Playwright CLI                        |
-| Section-level element screenshots   | Playwright CLI (`screenshot <ref>`)   |
+For CloudFlare-protected sites or quick one-shot captures. Handles CF bypass
+automatically via visible browser mode.
+
+```bash
+node scripts/scrape-page.js <url>
+```
+
+Outputs to `scraped/<timestamp>/`: `screenshot-desktop.png` (1280px),
+`screenshot-tablet.png` (768px), `screenshot-mobile.png` (375px), `page.html`,
+`metadata.json`.
 
 ## After capturing
 

--- a/.agents/skills/nebula-scrape-url/SKILL.md
+++ b/.agents/skills/nebula-scrape-url/SKILL.md
@@ -2,9 +2,9 @@
 name: nebula-scrape-url
 description:
   Capture web page screenshots and HTML for design reference. Use when the user
-  provides a URL and asks to build, recreate, or implement a design. Runs
-  `scripts/scrape-page.js` to capture desktop/tablet/mobile screenshots and
-  HTML. Not for Figma, GitHub, or documentation URLs.
+  provides a URL and asks to build, recreate, or implement a design. Supports
+  two modes — quick capture via scrape-page.js or interactive exploration via
+  Playwright CLI. Not for Figma, GitHub, or documentation URLs.
 ---
 
 # Scraping URLs for design reference
@@ -15,32 +15,115 @@ description:
 - GitHub URLs (read the code directly)
 - Documentation URLs (read or search as needed)
 
-## Workflow
+## Quick capture with scrape-page.js
 
-1. **Run the scraper** to capture screenshots and HTML:
+For simple, one-shot captures of a page. Handles CloudFlare-protected sites
+automatically via visible browser mode.
 
-   ```bash
-   node scripts/scrape-page.js <url>
-   ```
+```bash
+node scripts/scrape-page.js <url>
+```
 
-2. **Review the output** in `scraped/<timestamp>/`:
-   - `screenshot-desktop.png` - Desktop layout reference
-   - `screenshot-tablet.png` - Tablet layout reference
-   - `screenshot-mobile.png` - Mobile layout reference
-   - `page.html` - Full HTML for structure reference
+**Output** in `scraped/<timestamp>/`:
 
-3. **Use the screenshots** to understand the visual design (layout, spacing,
+- `screenshot-desktop.png` — 1280px width
+- `screenshot-tablet.png` — 768px width
+- `screenshot-mobile.png` — 375px width
+- `page.html` — complete HTML
+- `metadata.json` — page info
+
+**Options:**
+
+```bash
+node scripts/scrape-page.js <url> --headless        # skip visible browser
+node scripts/scrape-page.js <url> --no-screenshots   # HTML only
+```
+
+Use this when you just need reference screenshots and HTML to start building.
+
+## Interactive exploration with Playwright CLI
+
+For multi-step workflows: navigating pages, extracting computed styles,
+comparing Storybook renders against references, filling forms, or any iterative
+browser work.
+
+Run `playwright-cli --help` for all available commands.
+
+### Basic capture workflow
+
+```bash
+# Open page and capture at multiple viewports
+playwright-cli open https://example.com
+playwright-cli screenshot --full-page
+playwright-cli resize 768 1024
+playwright-cli screenshot --full-page
+playwright-cli resize 375 812
+playwright-cli screenshot --full-page
+playwright-cli close
+```
+
+Screenshots are saved to `.playwright-cli/` with timestamps.
+
+### Page structure extraction
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot                    # accessibility tree as YAML
+playwright-cli eval "document.title"       # evaluate JS expressions
+playwright-cli close
+```
+
+### Section-level screenshots
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot                    # find element refs
+playwright-cli screenshot e5              # screenshot specific element by ref
+playwright-cli close
+```
+
+### Extracting computed styles
+
+```bash
+playwright-cli open https://example.com
+playwright-cli eval "getComputedStyle(document.querySelector('.hero')).backgroundColor"
+playwright-cli eval "getComputedStyle(document.querySelector('h1')).fontFamily"
+```
+
+### Parallel sessions for comparison
+
+Use named sessions to have source and Storybook open simultaneously:
+
+```bash
+# Source in one session
+playwright-cli -s=source open https://example.com
+playwright-cli -s=source screenshot --full-page
+
+# Storybook in another
+playwright-cli -s=storybook open http://localhost:6006/iframe.html?id=organisms-hero--default
+playwright-cli -s=storybook screenshot --full-page
+
+# Compare the screenshots visually
+# Clean up
+playwright-cli close-all
+```
+
+## When to use which
+
+| Need                                | Tool                                  |
+| ----------------------------------- | ------------------------------------- |
+| Quick reference screenshots         | `scrape-page.js`                      |
+| CloudFlare-protected sites          | `scrape-page.js` (built-in CF bypass) |
+| Interactive page exploration        | Playwright CLI                        |
+| Extract CSS / computed styles       | Playwright CLI (`eval`)               |
+| Visual QA comparison loops          | Playwright CLI (named sessions)       |
+| Multi-step workflows (login, forms) | Playwright CLI                        |
+| Section-level element screenshots   | Playwright CLI (`screenshot <ref>`)   |
+
+## After capturing
+
+1. **Review the screenshots** to understand the visual design (layout, spacing,
    colors, typography).
-
-4. **Use the HTML** to understand the content structure and hierarchy.
-
-5. **Build the components** using the `nebula-component-creation` skill.
-
-## Example
-
-User prompt: "Build me this page: https://example.com/pricing"
-
-1. Run: `node scripts/scrape-page.js https://example.com/pricing`
-2. Review the screenshots to understand the layout
-3. Review the HTML to understand the structure
-4. Create components that match the design using Tailwind CSS
+2. **Review the HTML or snapshot** to understand content structure and
+   hierarchy.
+3. **Build the components** using the `nebula-component-creation` skill.

--- a/.agents/skills/nebula-storybook-stories/SKILL.md
+++ b/.agents/skills/nebula-storybook-stories/SKILL.md
@@ -3,7 +3,9 @@ name: nebula-storybook-stories
 description:
   Create Storybook stories for Canvas components. Use when (1) Creating a new
   component that needs a story, (2) Adding or modifying component stories, (3)
-  Verifying story files exist. Covers CSF3 format, argTypes, and decorators.
+  Verifying story files exist, (4) Organizing stories for larger projects.
+  Covers CSF3 format, argTypes, decorators, atomic design hierarchy, asset
+  management, and test stories.
 ---
 
 **CRITICAL: Every component MUST have an individual story file.**
@@ -51,3 +53,124 @@ ls src/stories/*.stories.jsx
 # Verify a specific component has its story
 ls src/stories/<component-name>.stories.jsx
 ```
+
+## Organizing with Atomic Design (recommended for larger projects)
+
+For projects with many components (15+) or when building full page compositions,
+organize stories using an Atomic Design hierarchy. This groups components by
+structural complexity and makes the Storybook sidebar navigable.
+
+**This is optional.** For small projects with a few components, the flat
+`src/stories/<name>.stories.jsx` structure works fine. Adopt atomic design when
+the flat list becomes hard to navigate.
+
+### Folder structure
+
+```
+src/stories/
+├── atoms/            # smallest building blocks
+│   ├── button.stories.jsx
+│   ├── heading.stories.jsx
+│   ├── text.stories.jsx
+│   ├── image.stories.jsx
+│   └── spacer.stories.jsx
+├── molecules/        # combinations of atoms
+│   ├── card.stories.jsx
+│   ├── blockquote.stories.jsx
+│   └── breadcrumb.stories.jsx
+├── organisms/        # complex UI sections
+│   ├── hero.stories.jsx
+│   ├── card-container.stories.jsx
+│   ├── header.stories.jsx
+│   └── footer.stories.jsx
+├── example-pages/    # full page compositions (see nebula-page-stories)
+│   └── home.stories.jsx
+└── tests/            # interactive test stories
+    └── slot-testing.stories.jsx
+```
+
+### Title convention
+
+Use the level name as a title prefix to group stories in the sidebar:
+
+```jsx
+// Atoms
+export default { title: "Atoms/Button", component: Button };
+
+// Molecules
+export default { title: "Molecules/Card", component: Card };
+
+// Organisms
+export default { title: "Organisms/Hero", component: Hero };
+```
+
+### Classification guide
+
+| Level    | Description                            | Examples                                          |
+| -------- | -------------------------------------- | ------------------------------------------------- |
+| Atom     | Single-purpose, no child components    | button, heading, text, image, spacer, logo, video |
+| Molecule | Combines 2-3 atoms into a unit         | card, blockquote, search form, breadcrumb         |
+| Organism | Complex section with multiple children | hero, card container, header, footer, navigation  |
+| Template | Page layout wrapper                    | PageLayout (see `nebula-page-stories`)            |
+| Page     | Full page composition                  | Home, About (see `nebula-page-stories`)           |
+| Test     | Stories for testing behaviors          | Slot testing, responsive testing                  |
+
+**How to classify:** If the component imports and renders other components from
+`@/components/`, it's at least a molecule. If it composes multiple molecules
+into a page section, it's an organism. If it stands alone with no child
+component imports, it's an atom.
+
+## Story assets
+
+Store shared story assets in `src/stories/assets/` with a barrel export for
+clean imports:
+
+```
+src/stories/assets/
+├── hero-bg.jpg
+├── logo.svg
+├── team-photo.jpg
+└── index.js
+```
+
+```js
+// src/stories/assets/index.js
+export { default as heroBg } from "./hero-bg.jpg";
+export { default as logo } from "./logo.svg";
+export { default as teamPhoto } from "./team-photo.jpg";
+```
+
+Then import in stories:
+
+```jsx
+import { heroBg, logo } from "../assets";
+```
+
+For placeholder images when real assets aren't available, use
+`https://placehold.co/<width>x<height>` URLs directly in story args.
+
+## Test stories
+
+Stories that exist for testing specific behaviors (not component documentation)
+go in the `Tests/` category with auto-docs disabled:
+
+```jsx
+export default {
+  title: "Tests/Slot Testing",
+  parameters: {
+    docs: { disable: true },
+  },
+};
+
+export const EmptySlots = {
+  render: () => <Section />,
+};
+
+export const NestedSlots = {
+  render: () => <Section content={<Card heading="Nested" />} />,
+};
+```
+
+Use test stories for: slot composition testing, responsive behavior
+verification, edge cases (very long text, missing props), and interactive state
+testing.

--- a/.agents/skills/nebula-storybook-stories/SKILL.md
+++ b/.agents/skills/nebula-storybook-stories/SKILL.md
@@ -1,110 +1,45 @@
 ---
 name: nebula-storybook-stories
 description:
-  Create Storybook stories for Canvas components. Use when (1) Creating a new
-  component that needs a story, (2) Adding or modifying component stories, (3)
-  Verifying story files exist, (4) Organizing stories for larger projects.
-  Covers CSF3 format, argTypes, decorators, atomic design hierarchy, asset
-  management, and test stories.
+  Create Storybook stories for Canvas components. Use when creating a new
+  component, adding variants, or organizing stories for larger projects. Covers
+  CSF3 format, argTypes, decorators, atomic design hierarchy, and story assets.
 ---
 
 **CRITICAL: Every component MUST have an individual story file.**
 
-Each component in `src/components/` requires a corresponding story file in
-`src/stories/`. The story file:
+Each component in `src/components/` requires a corresponding story in
+`src/stories/`. Story files are named `<component-name>.stories.jsx`
+(kebab-case), importing from `@/components/<component-name>`.
 
-- Must be named `<component-name>.stories.jsx` (kebab-case with hyphens)
-- Must import the component from `@/components/<component-name>`
-- Must showcase the component's props and variants
-
-**Example structure:**
-
-```
-src/components/my-card/
-├── index.jsx
-└── component.yml
-
-src/stories/my-card.stories.jsx  # Required story file for my-card component
-```
-
-## Name mapping
-
-Use this canonical mapping for component/story naming:
-
-- `component.yml machineName`: `my-card`
-- Component folder: `src/components/my-card/`
-- Component import: `@/components/my-card`
-- Story file: `src/stories/my-card.stories.jsx`
-
-**Story file requirements:**
-
-- Use Storybook CSF3 format (object-based stories).
-- Include `argTypes` for props with predefined options (like enums).
-- Create multiple story exports to showcase different variants.
-- Use decorators when components need specific backgrounds (e.g., dark
-  backgrounds for light-colored components).
-
-After creating components, verify story files exist:
-
-```bash
-# List all story files
-ls src/stories/*.stories.jsx
-
-# Verify a specific component has its story
-ls src/stories/<component-name>.stories.jsx
-```
-
-## Organizing with Atomic Design (recommended for larger projects)
-
-For projects with many components (15+) or when building full page compositions,
-organize stories using an Atomic Design hierarchy. This groups components by
-structural complexity and makes the Storybook sidebar navigable.
-
-**This is optional.** For small projects with a few components, the flat
-`src/stories/<name>.stories.jsx` structure works fine. Adopt atomic design when
-the flat list becomes hard to navigate.
-
-### Folder structure
-
-```
-src/stories/
-├── atoms/            # smallest building blocks
-│   ├── button.stories.jsx
-│   ├── heading.stories.jsx
-│   ├── text.stories.jsx
-│   ├── image.stories.jsx
-│   └── spacer.stories.jsx
-├── molecules/        # combinations of atoms
-│   ├── card.stories.jsx
-│   ├── blockquote.stories.jsx
-│   └── breadcrumb.stories.jsx
-├── organisms/        # complex UI sections
-│   ├── hero.stories.jsx
-│   ├── card-container.stories.jsx
-│   ├── header.stories.jsx
-│   └── footer.stories.jsx
-├── example-pages/    # full page compositions (see nebula-page-stories)
-│   └── home.stories.jsx
-└── tests/            # interactive test stories
-    └── slot-testing.stories.jsx
-```
-
-### Title convention
-
-Use the level name as a title prefix to group stories in the sidebar:
+**Story pattern:**
 
 ```jsx
-// Atoms
-export default { title: "Atoms/Button", component: Button };
+import Card from "@/components/card";
 
-// Molecules
-export default { title: "Molecules/Card", component: Card };
+export default {
+  title: "Molecules/Card",
+  component: Card,
+  argTypes: {
+    variant: { options: ["default", "featured"], control: "select" },
+  },
+};
 
-// Organisms
-export default { title: "Organisms/Hero", component: Hero };
+export const Default = { args: { heading: "Card Title" } };
+export const Featured = { args: { heading: "Featured", variant: "featured" } };
 ```
 
-### Classification guide
+- Include `argTypes` for props with predefined options (enums).
+- Create multiple exports to showcase variants.
+- Use decorators when components need specific backgrounds (e.g., dark bg for
+  light-colored components).
+
+## Atomic design organization
+
+For projects with many components (15+), organize stories into atomic design
+subfolders. For small projects, the flat `src/stories/` structure works fine.
+
+### Classification
 
 | Level    | Description                            | Examples                                          |
 | -------- | -------------------------------------- | ------------------------------------------------- |
@@ -120,46 +55,45 @@ export default { title: "Organisms/Hero", component: Hero };
 into a page section, it's an organism. If it stands alone with no child
 component imports, it's an atom.
 
+### Folder structure and title convention
+
+Place stories in `src/stories/<level>/` and prefix titles with the level name:
+
+```
+src/stories/
+├── atoms/            # title: "Atoms/Button"
+├── molecules/        # title: "Molecules/Card"
+├── organisms/        # title: "Organisms/Hero"
+├── example-pages/    # see nebula-page-stories
+└── tests/            # title: "Tests/Slot Testing"
+```
+
 ## Story assets
 
-Store shared story assets in `src/stories/assets/` with a barrel export for
-clean imports:
-
-```
-src/stories/assets/
-├── hero-bg.jpg
-├── logo.svg
-├── team-photo.jpg
-└── index.js
-```
+Store shared assets in `src/stories/assets/` with a barrel export:
 
 ```js
 // src/stories/assets/index.js
 export { default as heroBg } from "./hero-bg.jpg";
 export { default as logo } from "./logo.svg";
-export { default as teamPhoto } from "./team-photo.jpg";
 ```
-
-Then import in stories:
 
 ```jsx
 import { heroBg, logo } from "../assets";
 ```
 
-For placeholder images when real assets aren't available, use
-`https://placehold.co/<width>x<height>` URLs directly in story args.
+For placeholders, use `https://placehold.co/<width>x<height>` URLs directly in
+story args.
 
 ## Test stories
 
-Stories that exist for testing specific behaviors (not component documentation)
-go in the `Tests/` category with auto-docs disabled:
+Stories for testing behaviors (not component documentation) go in `Tests/` with
+auto-docs disabled:
 
 ```jsx
 export default {
   title: "Tests/Slot Testing",
-  parameters: {
-    docs: { disable: true },
-  },
+  parameters: { docs: { disable: true } },
 };
 
 export const EmptySlots = {
@@ -171,6 +105,5 @@ export const NestedSlots = {
 };
 ```
 
-Use test stories for: slot composition testing, responsive behavior
-verification, edge cases (very long text, missing props), and interactive state
-testing.
+Use test stories for: slot composition, responsive behavior, edge cases (long
+text, missing props), and interactive state testing.

--- a/.agents/skills/nebula-visual-qa/SKILL.md
+++ b/.agents/skills/nebula-visual-qa/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: nebula-visual-qa
+description:
+  Visual quality assurance for Canvas components. Compares Storybook renders
+  against design reference screenshots using Playwright CLI. Guides side-by-side
+  comparison at multiple viewports, severity classification, issue
+  documentation, and iterative fix-and-verify loops. Use after building
+  components to verify visual fidelity before upload. Requires Playwright CLI
+  and Storybook running.
+---
+
+# Visual QA for Canvas Components
+
+Compare Storybook component renders against design reference screenshots.
+Identify visual discrepancies, classify by severity, fix iteratively, and verify
+until components match the design.
+
+## Prerequisites
+
+- Playwright CLI installed (`@playwright/cli` — included in Nebula)
+- Storybook running (`npm run dev`)
+- Reference screenshots available (from `nebula-design-extraction`,
+  `nebula-figma-extraction`, or manual capture)
+
+## Arguments
+
+- `$1` — **Reference path** (required). Path to source screenshots directory.
+- `$2` — **Components** (optional). Comma-separated list of components to QA.
+  Defaults to all components with stories.
+- `$3` — **Design tokens path** (optional). Path to design-tokens.md for color
+  matching. Defaults to `docs/clone/design-tokens.md`.
+
+## Workflow
+
+### Step 1: Capture reference screenshots (if needed)
+
+If reference screenshots don't already exist from an extraction phase:
+
+```bash
+playwright-cli open <source-url> -s=source
+playwright-cli screenshot --full-page --filename=ref-desktop.png -s=source
+playwright-cli resize 375 812 -s=source
+playwright-cli screenshot --full-page --filename=ref-mobile.png -s=source
+playwright-cli close -s=source
+```
+
+### Step 2: Capture Storybook renders
+
+For each component, capture its Storybook story at matching viewports:
+
+```bash
+# Desktop (1280px default)
+playwright-cli open "http://localhost:6006/iframe.html?id=<story-id>&viewMode=story" -s=storybook
+playwright-cli screenshot --full-page --filename=built-hero-desktop.png -s=storybook
+
+# Mobile
+playwright-cli resize 375 812 -s=storybook
+playwright-cli screenshot --full-page --filename=built-hero-mobile.png -s=storybook
+
+# Reset for next component
+playwright-cli resize 1280 900 -s=storybook
+```
+
+Use named sessions to keep source and Storybook open simultaneously:
+
+```bash
+playwright-cli -s=source open <source-url>
+playwright-cli -s=storybook open http://localhost:6006/iframe.html?id=...
+playwright-cli -s=source screenshot --full-page
+playwright-cli -s=storybook screenshot --full-page
+```
+
+### Step 3: Side-by-side comparison
+
+Read both screenshots (source reference and Storybook render) and compare:
+
+**Layout**
+
+- Element positioning, flex/grid structure, alignment
+- Column count, row layout, wrapping behavior
+- Responsive reflow: does it stack correctly at mobile?
+
+**Colors**
+
+- Compare against `design-tokens.md` hex values, not just visual impression
+- Check: backgrounds, text colors, accent colors, borders, shadows
+- Example: source shows `#1a365d`, built shows `#2d3748` → HIGH severity
+
+**Typography**
+
+- Font family, weight, size, line-height, letter-spacing
+- Heading hierarchy consistency
+- Text alignment and truncation behavior
+
+**Spacing**
+
+- Padding, margins, gaps between elements
+- Section-level spacing consistency
+- Container max-widths
+
+**Effects**
+
+- Box shadows, border-radius, gradients
+- Opacity, backdrop-blur, overlays
+- Hover/focus states (if reference shows them)
+
+**Content**
+
+- All text matches reference exactly
+- Images present and correctly sized
+- Links/buttons all present
+
+### Step 4: Classify issues
+
+| Severity     | Definition                                  | Examples                                                                            |
+| ------------ | ------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Critical** | Component is structurally wrong or unusable | Wrong color scheme, missing element, layout broken, text invisible                  |
+| **High**     | Noticeable visual mismatch                  | Color off by more than one shade, wrong font weight, significant spacing difference |
+| **Medium**   | Minor visual difference                     | Slight spacing off, subtle color shade difference, minor border-radius mismatch     |
+| **Low**      | Negligible platform differences             | Sub-pixel rendering, anti-aliasing, browser-specific font smoothing                 |
+
+### Step 5: Document issues
+
+Create issue artifacts for each discrepancy found:
+
+```
+docs/qa/issues/
+├── 01-hero-wrong-color/
+│   ├── issue.md
+│   ├── source-desktop.png
+│   └── built-desktop.png
+├── 02-card-spacing/
+│   ├── issue.md
+│   ├── source-desktop.png
+│   └── built-desktop.png
+└── qa-summary.md
+```
+
+Issue format:
+
+```markdown
+# Issue 01: Hero Wrong Background Color
+
+**Component:** hero **Severity:** HIGH **Viewport:** desktop **Status:** open
+
+## Description
+
+Hero background uses gray-800 instead of primary-900.
+
+## Expected
+
+Background: #1a365d (design-tokens.md → --color-primary-900)
+
+## Actual
+
+Background: #2d3748 (bg-gray-800 in component)
+
+## Fix
+
+Change CVA variant `dark` background from `bg-gray-800` to `bg-primary-900` in
+hero/index.jsx.
+
+## Resolution
+
+[To be filled after fix]
+```
+
+### Step 6: Fix loop
+
+For each issue, starting from highest severity:
+
+1. **Fix ONE issue** — apply the minimal targeted change
+2. **Re-screenshot** the Storybook render at all viewports
+3. **Compare again** against the reference
+4. **Check for regressions** — did the fix break other components?
+5. **Update issue.md** — set status to `resolved`
+6. **Next issue** — repeat until no critical/high issues remain
+
+**Fix ONE at a time.** Never batch multiple fixes. Each fix gets its own verify
+cycle so regressions can be attributed to the specific change.
+
+### Common fix patterns
+
+| Issue Type       | Fix Location                      | Pattern                                |
+| ---------------- | --------------------------------- | -------------------------------------- |
+| Wrong color      | CVA variant or `@theme` token     | Map to correct design token            |
+| Wrong typography | `@theme` font or component styles | Match font-family, weight, size        |
+| Wrong spacing    | Tailwind classes                  | Match padding/margin/gap values        |
+| Layout broken    | Flex/grid structure               | Compare direction, alignment, wrapping |
+| Missing effect   | Component styles                  | Add shadow, gradient, blur             |
+| Responsive issue | Responsive Tailwind classes       | Add breakpoint-specific classes        |
+
+### Global.css impact awareness
+
+When fixing a design token in `global.css`, it may affect other components:
+
+```
+Changed --color-primary-900 in global.css.
+This affects: hero, header, footer, main-navigation.
+Re-verify these components after the fix.
+```
+
+### Step 7: QA summary
+
+Generate `docs/qa/qa-summary.md`:
+
+```markdown
+# Visual QA Summary
+
+## Overview
+
+- Components checked: 8
+- Viewports: desktop (1280px), mobile (375px)
+- Issues found: 5 (1 critical, 2 high, 1 medium, 1 low)
+- Issues resolved: 4
+- Issues deferred: 1 (low — sub-pixel rendering difference)
+
+## Per-Component Status
+
+| Component  | Desktop | Mobile            | Issues     | Status   |
+| ---------- | ------- | ----------------- | ---------- | -------- |
+| hero       | PASS    | PASS              | 1 resolved | verified |
+| card       | PASS    | PASS              | 0          | verified |
+| header     | PASS    | PASS              | 0          | verified |
+| footer     | PASS    | 1 medium resolved | 1 resolved | verified |
+| cta-banner | PASS    | PASS              | 0          | verified |
+
+## Deferred Issues
+
+- Low: footer border-radius differs by 1px at mobile (browser rendering)
+```
+
+## Iteration Behavior
+
+- **Iteration 1:** Full scan — screenshot ALL components at all viewports,
+  compare each against source, document all issues
+- **Iteration 2+:** Targeted — only re-check components that were fixed or share
+  design tokens with fixed components
+- **Regression detection:** After every fix, verify adjacent components
+
+## Exit Criteria
+
+- Zero critical issues
+- Zero high issues
+- Medium/low issues documented with rationale for deferral
+- All viewports verified (desktop + mobile minimum)
+
+## Standalone vs Sub-Agent Usage
+
+**Standalone:** Invoke directly to QA specific components after building them.
+Useful during development for continuous visual verification.
+
+**As sub-agent (via nebula-clone-page):** The orchestrator spawns a sub-agent
+with this skill loaded, passing the reference screenshots path, component list,
+and design-tokens.md path. The sub-agent runs the full QA loop and returns
+`qa-summary.md`.
+
+## Cleanup
+
+```bash
+playwright-cli close-all
+```

--- a/.agents/skills/nebula-visual-qa/SKILL.md
+++ b/.agents/skills/nebula-visual-qa/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: nebula-visual-qa
 description:
-  Visual quality assurance for Canvas components. Compares Storybook renders
-  against design reference screenshots using Playwright CLI. Guides side-by-side
+  Compare Canvas component Storybook renders against design reference
+  screenshots to find and fix visual discrepancies. Use after building
+  components, when verifying renders against source screenshots or Figma
+  exports, or when QA-ing visual fidelity before upload. Guides side-by-side
   comparison at multiple viewports, severity classification, issue
-  documentation, and iterative fix-and-verify loops. Use after building
-  components to verify visual fidelity before upload. Requires Playwright CLI
-  and Storybook running.
+  documentation, and iterative fix-and-verify loops.
+compatibility: Requires @playwright/cli and Storybook running (npm run dev).
 ---
 
 # Visual QA for Canvas Components
@@ -15,228 +16,86 @@ Compare Storybook component renders against design reference screenshots.
 Identify visual discrepancies, classify by severity, fix iteratively, and verify
 until components match the design.
 
-## Prerequisites
-
-- Playwright CLI installed (`@playwright/cli` — included in Nebula)
-- Storybook running (`npm run dev`)
-- Reference screenshots available (from `nebula-design-extraction`,
-  `nebula-figma-extraction`, or manual capture)
+Can be invoked standalone or as a sub-agent (via nebula-clone-page), which
+passes reference screenshots, component list, and design-tokens path
+automatically.
 
 ## Arguments
 
-- `$1` — **Reference path** (required). Path to source screenshots directory.
-- `$2` — **Components** (optional). Comma-separated list of components to QA.
+- `$1` -- **Reference path** (required). Path to source screenshots directory.
+- `$2` -- **Components** (optional). Comma-separated list of components to QA.
   Defaults to all components with stories.
-- `$3` — **Design tokens path** (optional). Path to design-tokens.md for color
+- `$3` -- **Design tokens path** (optional). Path to design-tokens.md for color
   matching. Defaults to `docs/clone/design-tokens.md`.
 
-## Workflow
+## QA Workflow
 
-### Step 1: Capture reference screenshots (if needed)
+- [ ] Capture reference screenshots (or use existing from extraction). See
+      `references/capture-commands.md`.
+- [ ] Capture Storybook renders at matching viewports. See
+      `references/capture-commands.md`.
+- [ ] Compare side-by-side: layout, colors, typography, spacing, effects,
+      content (checklist below).
+- [ ] Classify issues by severity (table below).
+- [ ] Document issues. See `references/issue-template.md`.
+- [ ] Fix loop: fix one issue, re-screenshot, compare, check regressions.
+- [ ] Generate qa-summary.md. See `references/qa-summary-template.md`.
 
-If reference screenshots don't already exist from an extraction phase:
-
-```bash
-playwright-cli open <source-url> -s=source
-playwright-cli screenshot --full-page --filename=ref-desktop.png -s=source
-playwright-cli resize 375 812 -s=source
-playwright-cli screenshot --full-page --filename=ref-mobile.png -s=source
-playwright-cli close -s=source
-```
-
-### Step 2: Capture Storybook renders
-
-For each component, capture its Storybook story at matching viewports:
-
-```bash
-# Desktop (1280px default)
-playwright-cli open "http://localhost:6006/iframe.html?id=<story-id>&viewMode=story" -s=storybook
-playwright-cli screenshot --full-page --filename=built-hero-desktop.png -s=storybook
-
-# Mobile
-playwright-cli resize 375 812 -s=storybook
-playwright-cli screenshot --full-page --filename=built-hero-mobile.png -s=storybook
-
-# Reset for next component
-playwright-cli resize 1280 900 -s=storybook
-```
-
-Use named sessions to keep source and Storybook open simultaneously:
-
-```bash
-playwright-cli -s=source open <source-url>
-playwright-cli -s=storybook open http://localhost:6006/iframe.html?id=...
-playwright-cli -s=source screenshot --full-page
-playwright-cli -s=storybook screenshot --full-page
-```
-
-### Step 3: Side-by-side comparison
+## Comparison Checklist
 
 Read both screenshots (source reference and Storybook render) and compare:
 
-**Layout**
+- **Layout** -- element positioning, flex/grid structure, alignment, column
+  count, responsive reflow/stacking at mobile
+- **Colors** -- compare against `design-tokens.md` hex values (backgrounds,
+  text, accents, borders, shadows)
+- **Typography** -- font family, weight, size, line-height, heading hierarchy,
+  text alignment
+- **Spacing** -- padding, margins, gaps, section-level spacing, container
+  max-widths
+- **Effects** -- box shadows, border-radius, gradients, opacity, overlays,
+  hover/focus states
+- **Content** -- all text matches reference exactly, images present and
+  correctly sized, links/buttons all present
 
-- Element positioning, flex/grid structure, alignment
-- Column count, row layout, wrapping behavior
-- Responsive reflow: does it stack correctly at mobile?
+## Severity Classification
 
-**Colors**
+| Severity     | Definition                                  | Examples                                                    |
+| ------------ | ------------------------------------------- | ----------------------------------------------------------- |
+| **Critical** | Component is structurally wrong or unusable | Wrong color scheme, missing element, layout broken          |
+| **High**     | Noticeable visual mismatch                  | Color off by more than one shade, wrong font weight         |
+| **Medium**   | Minor visual difference                     | Slight spacing off, subtle color shade, minor border-radius |
+| **Low**      | Negligible platform differences             | Sub-pixel rendering, anti-aliasing, browser font smoothing  |
 
-- Compare against `design-tokens.md` hex values, not just visual impression
-- Check: backgrounds, text colors, accent colors, borders, shadows
-- Example: source shows `#1a365d`, built shows `#2d3748` → HIGH severity
-
-**Typography**
-
-- Font family, weight, size, line-height, letter-spacing
-- Heading hierarchy consistency
-- Text alignment and truncation behavior
-
-**Spacing**
-
-- Padding, margins, gaps between elements
-- Section-level spacing consistency
-- Container max-widths
-
-**Effects**
-
-- Box shadows, border-radius, gradients
-- Opacity, backdrop-blur, overlays
-- Hover/focus states (if reference shows them)
-
-**Content**
-
-- All text matches reference exactly
-- Images present and correctly sized
-- Links/buttons all present
-
-### Step 4: Classify issues
-
-| Severity     | Definition                                  | Examples                                                                            |
-| ------------ | ------------------------------------------- | ----------------------------------------------------------------------------------- |
-| **Critical** | Component is structurally wrong or unusable | Wrong color scheme, missing element, layout broken, text invisible                  |
-| **High**     | Noticeable visual mismatch                  | Color off by more than one shade, wrong font weight, significant spacing difference |
-| **Medium**   | Minor visual difference                     | Slight spacing off, subtle color shade difference, minor border-radius mismatch     |
-| **Low**      | Negligible platform differences             | Sub-pixel rendering, anti-aliasing, browser-specific font smoothing                 |
-
-### Step 5: Document issues
-
-Create issue artifacts for each discrepancy found:
-
-```
-docs/qa/issues/
-├── 01-hero-wrong-color/
-│   ├── issue.md
-│   ├── source-desktop.png
-│   └── built-desktop.png
-├── 02-card-spacing/
-│   ├── issue.md
-│   ├── source-desktop.png
-│   └── built-desktop.png
-└── qa-summary.md
-```
-
-Issue format:
-
-```markdown
-# Issue 01: Hero Wrong Background Color
-
-**Component:** hero **Severity:** HIGH **Viewport:** desktop **Status:** open
-
-## Description
-
-Hero background uses gray-800 instead of primary-900.
-
-## Expected
-
-Background: #1a365d (design-tokens.md → --color-primary-900)
-
-## Actual
-
-Background: #2d3748 (bg-gray-800 in component)
-
-## Fix
-
-Change CVA variant `dark` background from `bg-gray-800` to `bg-primary-900` in
-hero/index.jsx.
-
-## Resolution
-
-[To be filled after fix]
-```
-
-### Step 6: Fix loop
+## Fix Loop Discipline
 
 For each issue, starting from highest severity:
 
-1. **Fix ONE issue** — apply the minimal targeted change
+1. **Fix ONE issue** -- apply the minimal targeted change
 2. **Re-screenshot** the Storybook render at all viewports
 3. **Compare again** against the reference
-4. **Check for regressions** — did the fix break other components?
-5. **Update issue.md** — set status to `resolved`
-6. **Next issue** — repeat until no critical/high issues remain
+4. **Check for regressions** -- did the fix break other components?
+5. **Update issue.md** -- set status to `resolved`
+6. **Next issue** -- repeat until no critical/high issues remain
 
-**Fix ONE at a time.** Never batch multiple fixes. Each fix gets its own verify
-cycle so regressions can be attributed to the specific change.
+Never batch multiple fixes. Each fix gets its own verify cycle so regressions
+can be attributed to the specific change.
 
-### Common fix patterns
+See `references/fix-patterns.md` for common fix patterns by issue type.
 
-| Issue Type       | Fix Location                      | Pattern                                |
-| ---------------- | --------------------------------- | -------------------------------------- |
-| Wrong color      | CVA variant or `@theme` token     | Map to correct design token            |
-| Wrong typography | `@theme` font or component styles | Match font-family, weight, size        |
-| Wrong spacing    | Tailwind classes                  | Match padding/margin/gap values        |
-| Layout broken    | Flex/grid structure               | Compare direction, alignment, wrapping |
-| Missing effect   | Component styles                  | Add shadow, gradient, blur             |
-| Responsive issue | Responsive Tailwind classes       | Add breakpoint-specific classes        |
+## Global.css Impact Awareness
 
-### Global.css impact awareness
-
-When fixing a design token in `global.css`, it may affect other components:
-
-```
-Changed --color-primary-900 in global.css.
-This affects: hero, header, footer, main-navigation.
-Re-verify these components after the fix.
-```
-
-### Step 7: QA summary
-
-Generate `docs/qa/qa-summary.md`:
-
-```markdown
-# Visual QA Summary
-
-## Overview
-
-- Components checked: 8
-- Viewports: desktop (1280px), mobile (375px)
-- Issues found: 5 (1 critical, 2 high, 1 medium, 1 low)
-- Issues resolved: 4
-- Issues deferred: 1 (low — sub-pixel rendering difference)
-
-## Per-Component Status
-
-| Component  | Desktop | Mobile            | Issues     | Status   |
-| ---------- | ------- | ----------------- | ---------- | -------- |
-| hero       | PASS    | PASS              | 1 resolved | verified |
-| card       | PASS    | PASS              | 0          | verified |
-| header     | PASS    | PASS              | 0          | verified |
-| footer     | PASS    | 1 medium resolved | 1 resolved | verified |
-| cta-banner | PASS    | PASS              | 0          | verified |
-
-## Deferred Issues
-
-- Low: footer border-radius differs by 1px at mobile (browser rendering)
-```
+When fixing a design token in `global.css`, it may affect other components.
+After changing any shared token (e.g., `--color-primary-900`), identify all
+components that use it and re-verify each one.
 
 ## Iteration Behavior
 
-- **Iteration 1:** Full scan — screenshot ALL components at all viewports,
-  compare each against source, document all issues
-- **Iteration 2+:** Targeted — only re-check components that were fixed or share
-  design tokens with fixed components
-- **Regression detection:** After every fix, verify adjacent components
+- **Iteration 1:** Full scan -- screenshot ALL components at all viewports,
+  compare each against source, document all issues.
+- **Iteration 2+:** Targeted -- only re-check components that were fixed or
+  share design tokens with fixed components.
+- **Regression detection:** After every fix, verify adjacent components.
 
 ## Exit Criteria
 
@@ -244,19 +103,4 @@ Generate `docs/qa/qa-summary.md`:
 - Zero high issues
 - Medium/low issues documented with rationale for deferral
 - All viewports verified (desktop + mobile minimum)
-
-## Standalone vs Sub-Agent Usage
-
-**Standalone:** Invoke directly to QA specific components after building them.
-Useful during development for continuous visual verification.
-
-**As sub-agent (via nebula-clone-page):** The orchestrator spawns a sub-agent
-with this skill loaded, passing the reference screenshots path, component list,
-and design-tokens.md path. The sub-agent runs the full QA loop and returns
-`qa-summary.md`.
-
-## Cleanup
-
-```bash
-playwright-cli close-all
-```
+- `qa-summary.md` generated (see `references/qa-summary-template.md`)

--- a/.agents/skills/nebula-visual-qa/references/capture-commands.md
+++ b/.agents/skills/nebula-visual-qa/references/capture-commands.md
@@ -1,0 +1,43 @@
+# Playwright CLI Capture Commands
+
+## Capture reference screenshots from source site
+
+```bash
+playwright-cli open <source-url> -s=source
+playwright-cli screenshot --full-page --filename=ref-desktop.png -s=source
+playwright-cli resize 375 812 -s=source
+playwright-cli screenshot --full-page --filename=ref-mobile.png -s=source
+playwright-cli close -s=source
+```
+
+## Capture Storybook renders
+
+```bash
+# Desktop (1280px default)
+playwright-cli open "http://localhost:6006/iframe.html?id=<story-id>&viewMode=story" -s=storybook
+playwright-cli screenshot --full-page --filename=built-hero-desktop.png -s=storybook
+
+# Mobile
+playwright-cli resize 375 812 -s=storybook
+playwright-cli screenshot --full-page --filename=built-hero-mobile.png -s=storybook
+
+# Reset for next component
+playwright-cli resize 1280 900 -s=storybook
+```
+
+## Named sessions for simultaneous comparison
+
+Keep source and Storybook open side-by-side:
+
+```bash
+playwright-cli -s=source open <source-url>
+playwright-cli -s=storybook open http://localhost:6006/iframe.html?id=...
+playwright-cli -s=source screenshot --full-page
+playwright-cli -s=storybook screenshot --full-page
+```
+
+## Cleanup
+
+```bash
+playwright-cli close-all
+```

--- a/.agents/skills/nebula-visual-qa/references/fix-patterns.md
+++ b/.agents/skills/nebula-visual-qa/references/fix-patterns.md
@@ -1,0 +1,10 @@
+# Common Fix Patterns
+
+| Issue Type       | Fix Location                      | Pattern                                |
+| ---------------- | --------------------------------- | -------------------------------------- |
+| Wrong color      | CVA variant or `@theme` token     | Map to correct design token            |
+| Wrong typography | `@theme` font or component styles | Match font-family, weight, size        |
+| Wrong spacing    | Tailwind classes                  | Match padding/margin/gap values        |
+| Layout broken    | Flex/grid structure               | Compare direction, alignment, wrapping |
+| Missing effect   | Component styles                  | Add shadow, gradient, blur             |
+| Responsive issue | Responsive Tailwind classes       | Add breakpoint-specific classes        |

--- a/.agents/skills/nebula-visual-qa/references/issue-template.md
+++ b/.agents/skills/nebula-visual-qa/references/issue-template.md
@@ -1,0 +1,45 @@
+# Issue Template
+
+Create one directory per issue under `docs/qa/issues/`:
+
+```
+docs/qa/issues/
+├── 01-hero-wrong-color/
+│   ├── issue.md
+│   ├── source-desktop.png
+│   └── built-desktop.png
+├── 02-card-spacing/
+│   ├── issue.md
+│   ├── source-desktop.png
+│   └── built-desktop.png
+└── qa-summary.md
+```
+
+## issue.md format
+
+```markdown
+# Issue 01: Hero Wrong Background Color
+
+**Component:** hero **Severity:** HIGH **Viewport:** desktop **Status:** open
+
+## Description
+
+Hero background uses gray-800 instead of primary-900.
+
+## Expected
+
+Background: #1a365d (design-tokens.md → --color-primary-900)
+
+## Actual
+
+Background: #2d3748 (bg-gray-800 in component)
+
+## Fix
+
+Change CVA variant `dark` background from `bg-gray-800` to `bg-primary-900` in
+hero/index.jsx.
+
+## Resolution
+
+[To be filled after fix]
+```

--- a/.agents/skills/nebula-visual-qa/references/qa-summary-template.md
+++ b/.agents/skills/nebula-visual-qa/references/qa-summary-template.md
@@ -1,0 +1,29 @@
+# QA Summary Template
+
+Generate as `docs/qa/qa-summary.md` after completing the QA pass.
+
+```markdown
+# Visual QA Summary
+
+## Overview
+
+- Components checked: 8
+- Viewports: desktop (1280px), mobile (375px)
+- Issues found: 5 (1 critical, 2 high, 1 medium, 1 low)
+- Issues resolved: 4
+- Issues deferred: 1 (low — sub-pixel rendering difference)
+
+## Per-Component Status
+
+| Component  | Desktop | Mobile            | Issues     | Status   |
+| ---------- | ------- | ----------------- | ---------- | -------- |
+| hero       | PASS    | PASS              | 1 resolved | verified |
+| card       | PASS    | PASS              | 0          | verified |
+| header     | PASS    | PASS              | 0          | verified |
+| footer     | PASS    | 1 medium resolved | 1 resolved | verified |
+| cta-banner | PASS    | PASS              | 0          | verified |
+
+## Deferred Issues
+
+- Low: footer border-radius differs by 1px at mobile (browser rendering)
+```

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ storybook-static
 # Scraped content (from scripts/scrape-page.js)
 scraped/
 
+# Playwright CLI output and config
+.playwright-cli/
+.playwright/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ building Drupal Canvas Code Components.
 | `nebula-design-extraction`    | Extract design tokens, screenshots, and content from a URL     |
 | `nebula-figma-extraction`     | Extract design tokens and content from a Figma file            |
 | `nebula-visual-qa`            | Visual QA comparison loop (Storybook vs design reference)      |
+| `nebula-clone-page`           | Clone a page from URL or Figma into Canvas components          |
 | `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ building Drupal Canvas Code Components.
 | `nebula-docs-explorer`        | Fetching Canvas and Drupal CMS documentation                   |
 | `nebula-frontend-design`      | Bold design direction for building distinctive components      |
 | `nebula-design-extraction`    | Extract design tokens, screenshots, and content from a URL     |
+| `nebula-figma-extraction`     | Extract design tokens and content from a Figma file            |
+| `nebula-visual-qa`            | Visual QA comparison loop (Storybook vs design reference)      |
 | `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ building Drupal Canvas Code Components.
 | `nebula-scrape-url`           | Capturing web pages for design reference                       |
 | `nebula-docs-explorer`        | Fetching Canvas and Drupal CMS documentation                   |
 | `nebula-frontend-design`      | Bold design direction for building distinctive components      |
+| `nebula-design-extraction`    | Extract design tokens, screenshots, and content from a URL     |
 | `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ building Drupal Canvas Code Components.
 | `nebula-page-stories`         | Composing page-level stories with PageLayout                   |
 | `nebula-scrape-url`           | Capturing web pages for design reference                       |
 | `nebula-docs-explorer`        | Fetching Canvas and Drupal CMS documentation                   |
+| `nebula-frontend-design`      | Bold design direction for building distinctive components      |
 | `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,47 @@
 Nebula is the template repository this project was scaffolded from, used for
 building Drupal Canvas Code Components.
 
-For all operations involving React components, the `component.yml` files, and
-`src/components/global.css` in this repository, load the
-`canvas-component-definition` skill.
+## Skills
 
-## Skill prefixes
+### Canvas skills (generic Canvas guidance)
 
-- `nebula-*` skills contain Nebula-specific conventions and workflows for this
-  repository.
-- `canvas-*` skills are generic Canvas component guidance.
+| Skill                            | When to load                                                            |
+| -------------------------------- | ----------------------------------------------------------------------- |
+| `canvas-component-definition`    | **Start here** for any React component task. Canonical Canvas contract. |
+| `canvas-component-metadata`      | Defining `component.yml` — props, slots, enums, examples                |
+| `canvas-component-composability` | Designing with slots, decomposition, parent/child patterns              |
+| `canvas-styling-conventions`     | Styling with Tailwind CSS 4 `@theme` tokens, CVA variants, `cn()`       |
+| `canvas-component-utils`         | Using `FormattedText`, `Image` from `drupal-canvas` package             |
+| `canvas-data-fetching`           | Fetching Drupal content with JSON:API and SWR                           |
+| `canvas-component-upload`        | Uploading components to Drupal Canvas                                   |
+
+### Nebula skills (repo-specific workflows)
+
+| Skill                         | When to load                                                   |
+| ----------------------------- | -------------------------------------------------------------- |
+| `nebula-project-structure`    | Understanding folder layout (`src/` vs `examples/`)            |
+| `nebula-component-creation`   | Creating new components by copying from `examples/components/` |
+| `nebula-component-validation` | Validating components before upload (`npm run code:fix`)       |
+| `nebula-storybook-stories`    | Creating Storybook stories for individual components           |
+| `nebula-page-stories`         | Composing page-level stories with PageLayout                   |
+| `nebula-scrape-url`           | Capturing web pages for design reference                       |
+| `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation
 
-Use the `nebula-component-validation` skill.
+Use the `nebula-component-validation` skill, or run `npm run code:fix` directly.
+
+## Browser automation
+
+This project includes two browser automation tools:
+
+- **`scripts/scrape-page.js`** — single-command page capture with CloudFlare
+  bypass. Use for quick reference screenshots.
+- **`@playwright/cli`** — interactive shell-based browser automation for
+  multi-step workflows (QA, extraction, form filling, comparison). Run
+  `playwright-cli --help` to discover commands. Use `-s=name` for parallel
+  sessions.
+
+Output from Playwright CLI goes to `.playwright-cli/` (gitignored).
+
+Load the `nebula-scrape-url` skill for detailed scraping workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ building Drupal Canvas Code Components.
 | `nebula-storybook-stories`    | Creating Storybook stories for individual components           |
 | `nebula-page-stories`         | Composing page-level stories with PageLayout                   |
 | `nebula-scrape-url`           | Capturing web pages for design reference                       |
+| `nebula-docs-explorer`        | Fetching Canvas and Drupal CMS documentation                   |
 | `implement-design`            | Translating Figma designs to code with 1:1 fidelity            |
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -25,6 +25,39 @@ npx @drupal-canvas/create@latest
   installed from
   [`drupal-canvas/skills`](https://github.com/drupal-canvas/skills).
 
+See `AGENTS.md` for a full skill index with descriptions of when to use each
+one.
+
+### Page cloning workflow
+
+The `nebula-clone-page` skill orchestrates cloning a web page or Figma design
+into Canvas components. It coordinates extraction, component building, visual
+QA, and page story composition via sub-agents:
+
+- **`nebula-design-extraction`** — extract design tokens, screenshots, and
+  verbatim content from a live site URL
+- **`nebula-figma-extraction`** — extract the same from a Figma file using the
+  REST API
+- **`nebula-visual-qa`** — side-by-side QA comparing Storybook renders against
+  design references with severity classification and fix loops
+- **`nebula-frontend-design`** — guide distinctive design decisions (adapted
+  from
+  [Anthropic's frontend-design skill](https://github.com/anthropics/skills),
+  Apache 2.0)
+- **`nebula-docs-explorer`** — fetch Canvas and Drupal CMS documentation on
+  demand
+
+### Browser automation
+
+Two browser automation tools are included:
+
+- **[`@playwright/cli`](https://github.com/microsoft/playwright-cli)** —
+  interactive shell-based browser automation for multi-step workflows (QA,
+  extraction, form filling). Token-efficient for AI agents. Run
+  `playwright-cli --help` for commands.
+- **`scripts/scrape-page.js`** — single-command page capture with CloudFlare
+  bypass for quick reference screenshots.
+
 ### Setup
 
 No setup is required for the following coding agents; they read directly from
@@ -83,6 +116,8 @@ is resolved, you'll be able to use the `npx skills check` and
 - [Prettier](https://prettier.io/) with plugins configured
   - [`prettier-plugin-tailwindcss`](https://www.npmjs.com/package/prettier-plugin-tailwindcss)
   - [`@ianvs/prettier-plugin-sort-imports`](https://www.npmjs.com/package/@ianvs/prettier-plugin-sort-imports)
+- [`@playwright/cli`](https://github.com/microsoft/playwright-cli) for
+  token-efficient browser automation in AI agent workflows
 - Pre-commit hook with [Husky](https://typicode.github.io/husky) for linting and
   formatting staged files using
   [`lint-staged`](https://www.npmjs.com/package/lint-staged)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@drupal-canvas/vite-plugin": "^0.1.0",
         "@eslint/js": "^9.39.1",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+        "@playwright/cli": "^0.1.1",
         "@storybook/addon-docs": "^10.0.8",
         "@storybook/react-vite": "^10.0.8",
         "@tailwindcss/vite": "^4.1.17",
@@ -1260,6 +1261,70 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.1.tgz",
+      "integrity": "sha512-9k11ZfDwAfMVDDIuEVW1Wvs8SoDNXIY1dNQ+9C9/SS8ZmElkcxesu5eoL7vNa96ntibUGaq1TM2qQoqvdl/I9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "playwright": "1.59.0-alpha-1771104257000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/cli/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/@playwright/cli/node_modules/playwright": {
+      "version": "1.59.0-alpha-1771104257000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0-alpha-1771104257000.tgz",
+      "integrity": "sha512-6SCMMMJaDRsSqiKVLmb2nhtLES7iTYawTWWrQK6UdIGNzXi8lka4sLKRec3L4DnTWwddAvCuRn8035dhNiHzbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.0-alpha-1771104257000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/cli/node_modules/playwright-core": {
+      "version": "1.59.0-alpha-1771104257000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0-alpha-1771104257000.tgz",
+      "integrity": "sha512-YiXup3pnpQUCBMSIW5zx8CErwRx4K6O5Kojkw2BzJui8MazoMUDU6E3xGsb1kzFviEAE09LFQ+y1a0RhIJQ5SA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "js-yaml": "^4.1.1",
     "lint-staged": "^16.2.6",
     "npm-run-all": "^4.1.5",
+    "@playwright/cli": "^0.1.1",
     "playwright": "^1.57.0",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.7.1",


### PR DESCRIPTION
## Summary

This PR contributes back patterns and tooling developed across three Canvas component projects (edu-site-mockup-ai, efi-ed, freelygive-ai) that built increasingly sophisticated AI-assisted workflows on top of Nebula. The contributions fall into three categories:

### 1. New Skills (6)

| Skill | Purpose |
|-------|---------|
| **`nebula-clone-page`** | Orchestrator that clones a web page or Figma design into Canvas components. Coordinates extraction → audit → build → visual QA → page story composition via sub-agents with specialized skills. |
| **`nebula-design-extraction`** | Extract design tokens, section screenshots, and verbatim content from a live website URL using Playwright CLI. |
| **`nebula-figma-extraction`** | Extract design tokens, frame screenshots, and content from Figma files using the REST API (avoids MCP rate limits). |
| **`nebula-visual-qa`** | Side-by-side visual QA comparing Storybook renders against design references. Includes severity classification, issue tracking, and iterative fix-and-verify loops. |
| **`nebula-frontend-design`** | Guide distinctive design decisions to avoid generic AI aesthetics. Adapted from [Anthropic's frontend-design skill](https://github.com/anthropics/skills) (Apache 2.0, attribution included). |
| **`nebula-docs-explorer`** | Fetch Canvas and Drupal CMS documentation on demand with a curated URL catalog and embedded known issues. |

### 2. Skill Enhancements (5)

| Skill | What changed |
|-------|-------------|
| **`canvas-data-fetching`** | Added content write operations (create/update/delete), page component structure, input format reference, media upload, and 6 common pitfalls. |
| **`canvas-component-upload`** | Added preflight validation pipeline (code:fix → validate → ssr-test), Storybook pre-check, post-upload Code Editor verification. |
| **`canvas-component-metadata`** | Added defensive prop handling patterns (null guards, string-or-object handling, FormattedText safety, CVA defaultVariants, slot minimum sizing). |
| **`nebula-storybook-stories`** | Added optional Atomic Design hierarchy for larger projects, classification guide, story assets pattern, test stories category. |
| **`nebula-scrape-url`** | Rewritten with two-tier approach: Playwright CLI (default) + scrape-page.js (CloudFlare fallback). |

### 3. Infrastructure

- **`@playwright/cli`** added as a devDependency — 4x more token-efficient than Playwright MCP for AI agents with filesystem access. Named sessions support parallel browser instances.
- **`.gitignore`** updated for `.playwright-cli/` and `.playwright/` output directories.
- **`AGENTS.md`** rewritten as a full skill index with "when to load" guidance and browser automation documentation.
- **`README.md`** updated with page cloning workflow, new skills, and browser automation sections.

### 4. Best Practices Refactor

All 11 skills were refactored following [agentskills.io best practices](https://agentskills.io/skill-creation/best-practices):

- **Descriptions** rewritten with imperative phrasing, under 1024 chars, user-intent focused
- **Progressive disclosure** — 6 skills now use `references/` directories, with context-aware loading instructions
- **Line counts reduced 53%** (2,750 → 1,300 total across SKILL.md files)
- **`compatibility`** fields added where needed
- **Checklists** for multi-step workflows
- **Defaults over menus** pattern applied
- **Gotchas/pitfalls** kept prominent in main SKILL.md

## Architecture: Skills-as-Agents Pattern

The `nebula-clone-page` orchestrator uses a **skills-as-agents** pattern — instead of formal agent definitions, it instructs the AI to spawn sub-agents with specific skills loaded. This:

- Works without Nebula agent support
- Is platform-agnostic (Claude Code, Copilot, Cursor, Gemini CLI, etc.)
- Makes all sub-skills independently usable
- Leverages the AI's native sub-agent capability

## What was intentionally excluded 
(from my personal workbench and experiments, so might not be relevent context for this PR)
- No Acquia Source-specific patterns or workarounds
- No formal agent definitions (`.claude/agents/`)
- No CMS admin operations (menus, site config)
- No platform-specific hacks or workarounds being fixed upstream

## Test plan

- [x] `npm install` succeeds with `@playwright/cli` added
- [x] `playwright-cli --help` works after install
- [x] `scripts/scrape-page.js` still works (kept as fallback)
- [x] `.playwright-cli/` output directory is properly gitignored
- [x] Pre-commit hooks pass on all modified files (Prettier + ESLint)
- [ ] Verify all skill descriptions trigger correctly on relevant prompts
- [ ] Test `nebula-clone-page` end-to-end with a real URL
- [ ] Test `nebula-figma-extraction` with a Figma file

🤖 Generated with [Claude Code](https://claude.com/claude-code)