### PR TITLE
fix(components): unsafe image prop access in components

### DIFF
--- a/examples/components/card/index.jsx
+++ b/examples/components/card/index.jsx
@@ -45,18 +45,19 @@ const Card = ({
 }) => {
   const cardBackgroundClassName = `card-${backgroundColor.substring(1)}`;
   const cardBackgroundClassNameOnHover = `card-${backgroundColorOnHover.substring(1)}`;
-  const { src, alt, width, height } = image;
+  const { src, alt, width, height } = image ?? {};
+  const hasImage = !!src;
 
   const cardContent = (
     <div
       className={cn(
-        cardVariants({ layout, textColor, image: !!image }),
+        cardVariants({ layout, textColor, image: hasImage }),
         cardBackgroundClassName,
         cardBackgroundClassNameOnHover,
         className,
       )}
     >
-      {image && (
+      {hasImage && (
         <Image
           {...{ src, alt, width, height }}
           className="w-full rounded-2xl object-cover object-center"

--- a/examples/components/hero/component.yml
+++ b/examples/components/hero/component.yml
@@ -2,6 +2,7 @@ name: Hero
 machineName: hero
 status: true
 required:
+  - backgroundImage
   - layout
   - headingSize
   - textColor

--- a/examples/components/hero/index.jsx
+++ b/examples/components/hero/index.jsx
@@ -22,10 +22,16 @@ const Hero = ({
   backgroundImage,
   darkenImage,
 }) => {
+  const backgroundImageUrl = backgroundImage?.src
+    ? `url(${backgroundImage.src})`
+    : undefined;
+
   return (
     <div
       className="flex min-h-[672px] w-full justify-start bg-cover bg-center bg-no-repeat"
-      style={{ backgroundImage: `url(${backgroundImage.src})` }}
+      style={
+        backgroundImageUrl ? { backgroundImage: backgroundImageUrl } : undefined
+      }
     >
       <div className={backgroundVariants({ darkenImage })}>
         <TwoColumnText

--- a/examples/components/image/component.yml
+++ b/examples/components/image/component.yml
@@ -1,7 +1,8 @@
 name: Image
 machineName: image
 status: true
-required: []
+required:
+  - image
 props:
   properties:
     image:

--- a/examples/components/image/index.jsx
+++ b/examples/components/image/index.jsx
@@ -1,7 +1,12 @@
 import { Image as ResponsiveImage } from "drupal-canvas";
 
 const Image = ({ image }) => {
+  if (!image?.src) {
+    return null;
+  }
+
   const { src, alt, width, height } = image;
+
   return (
     <ResponsiveImage
       {...{ src, alt, width, height }}

--- a/examples/components/logo_card/index.jsx
+++ b/examples/components/logo_card/index.jsx
@@ -1,7 +1,12 @@
 import { Image } from "drupal-canvas";
 
 const LogoCard = ({ backgroundColor = "#F1F5F9", image }) => {
+  if (!image?.src) {
+    return null;
+  }
+
   const { src, alt, width, height } = image;
+
   return (
     <div
       className="align-center flex max-h-33 max-w-50 flex-col justify-center gap-4 rounded-2xl p-6 leading-[normal]"

--- a/examples/components/two_column_text/index.jsx
+++ b/examples/components/two_column_text/index.jsx
@@ -98,10 +98,12 @@ const TwoColumnText = ({
 };
 
 const ContentImage = ({ image, className }) => {
-  if (!image) {
+  if (!image?.src) {
     return null;
   }
+
   const { src, alt, width, height } = image;
+
   return (
     <ResponsiveImage {...{ src, alt, width, height }} className={className} />
   );

--- a/examples/components/two_column_text/index.jsx
+++ b/examples/components/two_column_text/index.jsx
@@ -98,12 +98,10 @@ const TwoColumnText = ({
 };
 
 const ContentImage = ({ image, className }) => {
-  if (!image?.src) {
+  if (!image) {
     return null;
   }
-
   const { src, alt, width, height } = image;
-
   return (
     <ResponsiveImage {...{ src, alt, width, height }} className={className} />
   );


### PR DESCRIPTION
After [#3548282: Cannot delete default image from an optional image: it reappears](https://www.drupal.org/project/canvas/issues/3548282) components that expect an image to be always there can break. Let's make sure we're adding guards around using values from image props.