### PR TITLE
Add orchestration pipelines and update existing skills.

### DIFF
--- a/.agents/skills/build-and-deploy/SKILL.md
+++ b/.agents/skills/build-and-deploy/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: build-and-deploy
+description:
+  Full autonomous pipeline — takes any URL (Figma or web), builds Canvas
+  components, visually QAs them against the design reference, and uploads to
+  Canvas without any manual prompts in between. Use when the user wants a fully
+  hands-off run from URL to deployed components. Triggers on phrases like "do
+  everything", "full pipeline", "build and deploy", "hands-off", "run the full
+  loop", or "ralph loop".
+metadata:
+  mcp-server: figma, figma-desktop # optional — pipeline works without it
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Build and Deploy — Full Autonomous Pipeline
+
+Runs the complete workflow from URL to a live Canvas page without stopping for
+human input. Only stops if a hard error occurs that cannot be recovered
+automatically.
+
+## Pipeline Overview
+
+```
+URL provided
+    │
+    ▼
+Phase 1 — Build from URL              (build-from-url skill logic)
+    │
+    ▼
+Phase 2 — Visual QA Loop              (visual-qa-loop skill logic)  ← MANDATORY, multi-iteration
+    │
+    ▼
+Phase 3 — Validate & Re-QA & Upload
+    ├── 3a  Validate (nebula-component-validation / npm run code:fix)
+    ├── 3b  Visual QA again            ← MANDATORY after validation, auto-fix can shift output
+    └── 3c  Upload (canvas-component-upload)
+    │
+    ▼
+Phase 4 — Build Canvas Page           (content-management skill)    ← MANDATORY, do not skip
+    │
+    ▼
+Done — report summary
+```
+
+---
+
+## Rules for Autonomous Operation
+
+- **Do not ask clarifying questions** mid-run. Make reasonable decisions and
+  document them in the final report.
+- **Do not stop on warnings** — only stop on errors that block progress (missing
+  credentials, MCP connection failure, Storybook won't start).
+- **On recoverable errors** (upload conflict, lint error, hot reload delay) —
+  retry up to 3 times before reporting as a blocker.
+- **Max QA iterations per component:** 5. If a component still has gaps after 5
+  iterations, mark it as "needs manual review" and continue with the rest.
+- **At the end**, always output a structured summary (see
+  [Final Report](#final-report)).
+
+### HARD RULES — never skip these
+
+> ⛔ **Phase 2 is NOT optional.** A single screenshot glance is NOT QA. You MUST
+> complete the full visual-qa-loop for every component before proceeding to
+> Phase 3. "Looks close enough" is not acceptable — follow the full loop
+> including style manifest extraction and numeric diffing.
+
+> ⛔ **Phase 4 is NOT optional.** Uploading components is not "deployed".
+> Deployed means a Canvas page exists with those components arranged to match
+> the source URL. You MUST complete Phase 4. If page assembly is genuinely
+> blocked (e.g. missing site credentials), document why in the final report — do
+> NOT silently skip it.
+
+---
+
+## Phase 1: Build from URL
+
+Follow the full `build-from-url` skill:
+
+1. **Detect URL type**
+   - `figma.com/design/` or `figma.com/board/` → Figma URL, skip capture
+   - Any other URL → Web URL, run Playwright capture to Figma first
+
+2. **If Web URL — Playwright capture first (always)**
+   - Open at 1440×900 via playwright-cli (headed, Chrome)
+   - Dismiss popups/overlays
+   - Measure page height, detect sticky header
+   - Extract style manifest (computed font/color/spacing tokens from live DOM)
+   - Screenshot each section → save as reference images
+
+3. **If Figma MCP is connected — also capture to Figma**
+   - Create new Figma file via `generate_figma_design(outputMode: "newFile")`
+   - Capture each 900px section into Figma, poll until complete
+   - Save `fileKey` for design context extraction
+
+   **If Figma MCP is not connected** — skip this step, use Playwright
+   screenshots and style manifest as the build reference instead.
+
+4. **Fetch design context (Figma MCP only)**
+   - `get_design_context(fileKey, nodeId)` for each section/component
+   - If too large, use `get_metadata` then fetch child nodes individually
+
+5. **Get visual reference** — Figma screenshot if available, otherwise the
+   Playwright reference images from step 2
+
+6. **Build components**
+   - Follow `nebula-component-creation` patterns
+   - Apply `canvas-styling-conventions` for tokens and CVA variants
+   - Apply `canvas-component-definition` contract
+   - Apply `canvas-component-metadata` for `component.yml`
+   - Apply `canvas-component-utils` for FormattedText/Image
+
+7. **Create Storybook stories** — follow `nebula-storybook-stories` for each
+   component
+
+---
+
+## Phase 2: Visual QA Loop
+
+> ⛔ This phase is **MANDATORY**. Do not proceed to Phase 3 until every
+> component has passed all steps below. One pass is not enough.
+
+For each component built in Phase 1, execute the **full** visual-qa-loop skill:
+
+1. **Ensure Storybook is running** at `http://localhost:6006`
+   - If not, run `npm run dev` in background and wait for it to respond
+
+2. **Get reference screenshot** — screenshot the live site section at 1440px
+   that corresponds to this component (scroll to the correct Y offset, dismiss
+   any overlays first)
+
+3. **Extract style manifest from live site** — run the computed-style eval from
+   the visual-qa-loop skill (Step 3B-extra) and save the output
+
+4. **Screenshot the Storybook story**
+   - URL: `http://localhost:6006/iframe.html?id=<story-id>&viewMode=story`
+   - Resize to 1440×900 before screenshotting
+
+5. **Extract style manifest from Storybook story** — run the same computed-style
+   eval against the Storybook iframe
+
+6. **Compare both** — screenshot side-by-side AND numeric style manifest diff:
+   - Layout: alignment, spacing, padding, margins
+   - Typography: font-family, size, weight, line-height, color
+   - Colors: backgrounds, text, borders
+   - Components: icons, images, buttons
+
+7. **If ANY discrepancy found** (visual OR numeric, beyond ≤2px tolerance):
+   - Fix `src/components/<name>/index.jsx`
+   - Wait 2 seconds for hot reload
+   - Re-screenshot and re-extract styles
+   - Return to step 6
+   - Repeat up to 5 times total
+   - After 5 iterations → mark as "needs manual review", document remaining gaps
+
+8. **A component is only "Matched" when ALL of the following are true:**
+   - Screenshot comparison shows no visible structural differences
+   - Style manifest diff shows no numeric mismatches beyond ≤2px/2% tolerance
+   - At least one full iteration (screenshot + style diff) was completed
+
+9. **If no discrepancies** → proceed to next component, then Phase 3
+
+---
+
+## Phase 3: Validate and Upload
+
+1. **Validate all components**
+
+   ```bash
+   npm run code:fix
+   ```
+
+   Fix any lint or formatting errors. Retry up to 3 times.
+
+2. **Re-run visual QA after validation** — ESLint/Prettier auto-fix can rewrite
+   JSX in ways that shift visual output. After `code:fix` passes, run the full
+   `visual-qa-loop` again for every component. Only proceed to upload once every
+   component still passes the visual QA check.
+
+   > ⛔ **This QA pass is mandatory.** A clean lint run does not mean the
+   > component still matches the reference. Do not upload until this second QA
+   > pass confirms it.
+
+3. **Upload components to Canvas** — follow `canvas-component-upload` skill,
+   handle dependency ordering, retry on conflict errors.
+
+4. **Upload global CSS** — always run after uploading components:
+
+   ```bash
+   npx canvas upload -d ./src/components --css-only -y
+   ```
+
+---
+
+## Phase 4: Build Canvas Page
+
+> ⛔ This phase is **MANDATORY**. Do not report "done" until the page exists on
+> Canvas with the components placed and configured.
+
+1. **Identify the target page** — use the `content-management` skill to check if
+   a page for this URL already exists on the Canvas site. If it does, update it.
+   If not, create a new one.
+
+2. **Assemble the page** — for each section of the source URL, place the
+   corresponding uploaded component onto the Canvas page and configure its props
+   to match the source content (headings, images, text, links).
+
+3. **Verify the live Canvas page** — open the published Canvas page URL in
+   playwright-cli and take a screenshot. Compare it against the source URL
+   screenshot from Phase 1. Note any structural differences in the final report.
+
+4. **If page assembly is blocked** (e.g. missing Canvas page-building
+   credentials, API errors that cannot be recovered after 3 retries) — document
+   the specific blocker in the final report. Do NOT silently skip this phase.
+
+---
+
+## Final Report
+
+At the end of the run, output a summary in this format:
+
+```
+## Build and Deploy — Summary
+
+**Source:** <URL provided>
+**Canvas page:** <URL of the assembled Canvas page, or "blocked — see notes">
+
+### Components
+| Component    | Built | QA Iterations | QA Status        | Uploaded |
+|--------------|-------|---------------|------------------|----------|
+| hero         | ✅    | 3             | ✅ Matched        | ✅       |
+| school_card  | ✅    | 1             | ✅ Matched        | ✅       |
+| cta_banner   | ✅    | 2             | ⚠️ Needs review   | ✅       |
+
+### Page Assembly
+| Step                        | Status |
+|-----------------------------|--------|
+| Canvas page created/updated | ✅ / ❌ |
+| Components placed           | ✅ / ❌ |
+| Live page verified          | ✅ / ❌ |
+
+### Notes
+- <any decisions made autonomously>
+- <any components flagged for manual review and why>
+- <any errors encountered and how they were resolved>
+- <reason if Phase 4 was blocked>
+```

--- a/.agents/skills/build-from-url/SKILL.md
+++ b/.agents/skills/build-from-url/SKILL.md
@@ -1,0 +1,360 @@
+---
+name: build-from-url
+description:
+  Build or implement a UI from any URL. Auto-detects the URL type — if it's a
+  Figma URL, builds directly using the Figma MCP; if it's any other web page
+  URL, captures Playwright screenshots and style tokens first (always), then
+  also converts to Figma if the MCP is connected for extra precision. Falls back
+  gracefully to Playwright-only if Figma MCP is not available — no manual setup
+  required. Use when the user shares any URL (Figma or web) with intent to
+  build, implement, recreate, or match a design. Triggers on phrases like "build
+  this", "implement this", "recreate this page", or any URL shared alongside a
+  build request.
+metadata:
+  mcp-server: figma, figma-desktop # optional — pipeline works without it
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Build from URL
+
+## URL Detection
+
+Check the URL the user shared:
+
+- Contains `figma.com/design/` or `figma.com/board/` → **Figma URL**, skip to
+  [Phase 2a: Build from Figma](#phase-2a-build-from-figma)
+- Any other URL → **Web URL**, start at
+  [Phase 1: Playwright Capture](#phase-1-playwright-capture-web-urls--always-run)
+
+---
+
+## Phase 1: Playwright Capture (Web URLs — always run)
+
+This phase is **always required** for web URLs. It produces the reference
+screenshots and style manifest used throughout the build and in Phase 3 QA.
+Figma MCP is not needed for this phase.
+
+### 1.1 — Open the page
+
+```bash
+playwright-cli open <URL> --browser=chrome
+playwright-cli resize 1440 900
+```
+
+Wait for the page to fully load.
+
+### 1.2 — Dismiss popups and overlays
+
+Try clicking common dismiss buttons:
+
+```bash
+playwright-cli click [aria-label*="Accept"]
+playwright-cli click [id*="cookie"] button
+playwright-cli click [class*="consent"] button
+```
+
+If a button was clicked, wait 500ms. Then suppress remaining overlays and
+restore scroll:
+
+```bash
+playwright-cli eval "document.querySelectorAll('[id*=\"cookie\"],[class*=\"cookie\"],[class*=\"consent\"],[class*=\"popup\"],[class*=\"banner\"],[class*=\"overlay\"]').forEach(el => el.style.display = 'none'); document.body.style.overflow = 'auto'"
+```
+
+### 1.3 — Measure the page
+
+```bash
+playwright-cli eval "document.documentElement.scrollHeight"
+playwright-cli eval "document.title"
+```
+
+Calculate sections: `ceil(height / 900)`
+
+### 1.3b — Extract design tokens from the live site
+
+Extract the site's actual computed styles so the build uses exact values rather
+than approximations. Save all three outputs as the **style manifest** — used in
+Phase 2 and `global.css`.
+
+**Typography and color tokens:**
+
+```bash
+playwright-cli eval "
+const targets = {
+  heading1: 'h1',
+  heading2: 'h2',
+  heading3: 'h3',
+  body: 'p',
+  nav: 'nav a, header a',
+  button: 'button, a[class*=\"btn\"], a[class*=\"button\"]',
+  header: 'header',
+  footer: 'footer',
+};
+const tokens = {};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  tokens[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    textTransform: s.textTransform,
+    padding: s.padding,
+    borderRadius: s.borderRadius,
+  };
+}
+JSON.stringify(tokens, null, 2)
+"
+```
+
+**Color palette:**
+
+```bash
+playwright-cli eval "
+const colors = new Map();
+document.querySelectorAll('*').forEach(el => {
+  const s = getComputedStyle(el);
+  const tag = el.tagName.toLowerCase();
+  if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)')
+    colors.set(s.backgroundColor, (colors.get(s.backgroundColor) || 0) + 1);
+  if (s.color)
+    colors.set(s.color, (colors.get(s.color) || 0) + 1);
+});
+JSON.stringify([...colors.entries()].sort((a,b) => b[1]-a[1]).slice(0,20).map(([c,n]) => ({color:c,count:n})))
+"
+```
+
+**Web fonts loaded:**
+
+```bash
+playwright-cli eval "
+[...document.fonts].map(f => ({ family: f.family, style: f.style, weight: f.weight, status: f.status }))
+  .filter(f => f.status === 'loaded')
+  .map(f => f.family + ' ' + f.weight)
+  .filter((v,i,a) => a.indexOf(v) === i)
+"
+```
+
+### 1.4 — Detect sticky header
+
+```bash
+playwright-cli eval "window.scrollTo(0, 200)"
+playwright-cli eval "window.scrollTo(0, 0)"
+playwright-cli eval "window.__stickyEls = Array.from(document.querySelectorAll('*')).filter(el => { const s = getComputedStyle(el); return (s.position === 'fixed' || s.position === 'sticky') && el.getBoundingClientRect().top < 200; }); window.__stickyEls.reduce((h, el) => h + el.getBoundingClientRect().height, 0)"
+```
+
+Save the result as `stickyHeight` (0 if none).
+
+### 1.5 — Screenshot each section (reference images)
+
+For each section at `scrollY = 0, 900, 1800, ...`:
+
+1. Scroll to position and wait 1 second for content to settle
+2. For sections after the first (`scrollY > 0`), hide sticky elements
+3. Take a screenshot and save to `.playwright-cli/<section-name>-reference.png`
+4. Note the pixel boundaries (top/bottom Y) of each distinct visual section
+5. Restore sticky elements after each screenshot
+
+These reference images are the source of truth for Phase 3 QA.
+
+---
+
+## Figma MCP Check
+
+> After completing Phase 1, check whether Figma MCP tools are available.
+
+- **Figma MCP connected** → proceed to
+  [Phase 1.6: Capture to Figma](#phase-16-capture-to-figma-optional--figma-mcp-connected)
+  for enhanced design context, then build via **Phase 2a**
+- **Figma MCP not connected** → skip Phase 1.6, proceed directly to
+  **[Phase 2b: Build from Playwright Reference](#phase-2b-build-from-playwright-reference-figma-mcp-not-connected)**
+
+Both paths produce the same output quality. Figma adds exact design-token
+extraction on top of what Playwright already captured.
+
+---
+
+## Phase 1.6: Capture to Figma (optional — Figma MCP connected)
+
+### 1.6a — Create a new Figma file
+
+```
+generate_figma_design(outputMode: "newFile", fileName: "<page title>")
+```
+
+Save the `fileKey` from the response.
+
+### 1.6b — Capture each section
+
+For each section at `scrollY = 0, 900, 1800, ...`:
+
+1. Scroll to position:
+   ```bash
+   playwright-cli eval "window.scrollTo(0, <scrollY>)"
+   ```
+2. Wait 1 second for content to settle.
+3. For sections after the first (`scrollY > 0`), hide sticky elements:
+   ```bash
+   playwright-cli eval "window.__stickyEls.forEach(el => el.style.visibility = 'hidden')"
+   ```
+4. Inject Figma's capture script:
+   ```bash
+   playwright-cli eval "fetch('https://mcp.figma.com/mcp/html-to-design/capture.js').then(r=>r.text()).then(t=>{const s=document.createElement('script');s.textContent=t;document.head.appendChild(s)})"
+   ```
+5. Get a new captureId:
+   ```
+   generate_figma_design(outputMode: "existingFile", fileKey: "<fileKey>")
+   ```
+6. Trigger capture:
+   ```bash
+   playwright-cli eval "window.figma.captureForDesign({ captureId: '<captureId>', endpoint: '<endpoint>', selector: 'body' })"
+   ```
+7. Poll `generate_figma_design(captureId: "<captureId>")` every 5 seconds until
+   status is `completed`.
+8. Restore sticky elements:
+   ```bash
+   playwright-cli eval "window.__stickyEls.forEach(el => el.style.visibility = '')"
+   ```
+
+### 1.6c — Close browser
+
+```bash
+playwright-cli close
+```
+
+Share the direct Figma file link, then continue to **Phase 2a**.
+
+---
+
+## Phase 2a: Build from Figma
+
+_Use this path when Figma MCP is connected (either a direct Figma URL, or after
+Phase 1.6 capture)._
+
+### 2a.1 — Parse fileKey and nodeId
+
+For Figma URLs: `https://figma.com/design/:fileKey/:fileName?node-id=1-2`
+
+- **fileKey**: segment after `/design/`
+- **nodeId**: `node-id` query param value (convert `-` to `:`)
+
+For pages captured in Phase 1.6: use the `fileKey` from the capture response.
+
+### 2a.2 — Fetch design context
+
+```
+get_design_context(fileKey=":fileKey", nodeId="1:2")
+```
+
+If the response is too large, use `get_metadata` first to get the node map, then
+fetch specific child nodes individually.
+
+### 2a.3 — Get visual reference
+
+```
+get_screenshot(fileKey=":fileKey", nodeId="1:2")
+```
+
+Keep this screenshot as the source of truth throughout implementation.
+
+### 2a.4 — Download assets
+
+Use any `localhost` URLs returned by the Figma MCP server directly. Do not
+import new icon packages or create placeholders.
+
+### 2a.5 — Build components
+
+- Follow `nebula-component-creation` patterns
+- **Use the style manifest from Phase 1.3b as the primary source of truth** for
+  all numeric values — exact font sizes, weights, colors, spacing
+- Add site-specific colors to `src/components/global.css` as `@theme` CSS
+  variables before writing component code
+- Load any web fonts from the manifest via `@import url(...)` in `global.css`
+- Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+- Apply `canvas-component-definition` contract
+- Apply `canvas-component-metadata` for `component.yml`
+- Apply `canvas-component-utils` for FormattedText/Image
+- Create Storybook story per `nebula-storybook-stories`
+
+### 2a.6 — Validate checklist
+
+- [ ] Layout matches (spacing, alignment, sizing)
+- [ ] Typography matches (font, size, weight, line height)
+- [ ] Colors match exactly
+- [ ] Interactive states work (hover, active, disabled)
+- [ ] Assets render correctly
+- [ ] Accessibility standards met
+
+---
+
+## Phase 2b: Build from Playwright Reference (Figma MCP not connected)
+
+_Use this path when Figma MCP is not available. The reference screenshots from
+Phase 1.5 and style manifest from Phase 1.3b replace Figma as the source of
+truth._
+
+### 2b.1 — Identify components from reference screenshots
+
+Review the section screenshots saved in Phase 1.5. Identify each distinct visual
+component (navbar, hero, cards, footer, etc.) and note its pixel boundaries.
+
+### 2b.2 — Build components
+
+- Follow `nebula-component-creation` patterns
+- **Use the style manifest from Phase 1.3b as the source of truth** for all
+  token values:
+  - Add site-specific colors to `src/components/global.css` as `@theme` CSS
+    variables
+  - Use exact `font-size`, `font-weight`, `line-height`, `letter-spacing` values
+    from the manifest
+  - Match `padding` and `border-radius` to the extracted values
+  - Load web fonts found in the manifest via `@import url(...)` in `global.css`
+- Use the Playwright reference screenshots as the visual guide for layout and
+  proportions
+- Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+- Apply `canvas-component-definition` contract
+- Apply `canvas-component-metadata` for `component.yml`
+- Apply `canvas-component-utils` for FormattedText/Image
+- Create Storybook story per `nebula-storybook-stories`
+
+### 2b.3 — Validate checklist
+
+- [ ] Layout matches reference screenshot (spacing, alignment, sizing)
+- [ ] Typography matches style manifest values exactly
+- [ ] Colors match style manifest palette
+- [ ] Interactive states work (hover, active, disabled)
+- [ ] Accessibility standards met
+
+---
+
+## Phase 3: Visual QA Loop (MANDATORY)
+
+**This phase is NOT optional.** After building components and creating stories,
+you MUST run the visual QA loop before considering the build complete. The
+reference screenshots from Phase 1.5 are the QA baseline — Figma MCP is not
+required.
+
+### 3.1 — Run the visual-qa-loop skill
+
+Invoke the `visual-qa-loop` skill with the original URL and the Phase 1.5
+reference screenshots as the design reference. This will:
+
+1. Screenshot each component story in Storybook
+2. Compare against the reference screenshots (and Figma if available)
+3. Fix discrepancies (typography, spacing, colors, layout)
+4. Re-screenshot and iterate until visual parity is achieved
+5. Run final validation (`npm run code:fix`)
+
+### 3.2 — Completion criteria
+
+The build is **only complete** when:
+
+- [ ] All components pass visual QA (no discrepancies > 2px)
+- [ ] `npm run code:fix` exits with 0 errors
+- [ ] `npm run build` succeeds
+
+**Do NOT report the build as finished until Phase 3 is done.**

--- a/.agents/skills/canvas-component-metadata/SKILL.md
+++ b/.agents/skills/canvas-component-metadata/SKILL.md
@@ -238,6 +238,56 @@ examples:
   - 1
 ```
 
+## Array and object data — MANDATORY decision gate
+
+Canvas **does not support** `type: array` or inline `properties` objects in
+`component.yml`. Whenever you encounter or author a prop that holds a list or
+object value, you **must** decompose it into slots and child components.
+**Silently removing the array prop with no replacement is never acceptable** —
+it leaves components rendering empty/broken content.
+
+### Only strategy — Slots
+
+Every list or structured object prop must become a slot. Decompose the parent
+component to accept child components via a named slot, and create a child
+component for each item type. See the **Slots** section and the
+`canvas-component-composability` skill for full decomposition rules.
+
+```yaml
+# parent component.yml
+slots:
+  links:
+    title: Links
+```
+
+```jsx
+// parent index.jsx
+const Hero = ({ heading, links }) => (
+  <section>
+    <h1>{heading}</h1>
+    <ul>{links}</ul>
+  </section>
+);
+```
+
+Child components (e.g., `link_item`) are placed inside the slot via
+`parent_uuid` + `slot` on the Canvas page.
+
+> ⛔ **Do NOT use JSON string serialization** (`propNameJson: type: string` +
+> `JSON.parse`). It is not a supported pattern — it bypasses the Canvas editor
+> and makes content uneditable by authors.
+
+### Checklist when touching any array/object prop
+
+- [ ] Decomposed array prop into a named slot in `component.yml`
+- [ ] Created or reused a child component for each item type
+- [ ] Parent JSX consumes the named slot prop directly (no `JSON.parse`)
+- [ ] Canvas page updated — child components reference the correct `parent_uuid`
+      and `slot` name
+- [ ] **Never left an array prop removed with no replacement**
+
+---
+
 ## Enums
 
 Enum values must use lowercase, machine-friendly identifiers. Use `meta:enum` to

--- a/.agents/skills/canvas-component-upload/SKILL.md
+++ b/.agents/skills/canvas-component-upload/SKILL.md
@@ -89,3 +89,20 @@ Example scenario:
 
 If uploads continue to fail after multiple retries, check that all dependency
 components are included in the upload command.
+
+## Upload Global CSS (MANDATORY)
+
+**After uploading components, ALWAYS upload the global CSS.** Components depend
+on Tailwind theme tokens and custom properties defined in `global.css`. Without
+this step, components will render without styles on Canvas.
+
+```bash
+npx canvas upload -d ./src/components --css-only -y
+```
+
+This builds Tailwind CSS from all component classes and uploads the resulting
+stylesheet to Canvas. **Do NOT skip this step** — even if only component code
+changed, the CSS must be re-uploaded to include any new utility classes.
+
+The upload is only complete when both components AND global CSS have been
+pushed.

--- a/.agents/skills/content-management/SKILL.md
+++ b/.agents/skills/content-management/SKILL.md
@@ -1,0 +1,450 @@
+---
+name: content-management
+description:
+  Managing content in Acquia Source via JSON:API including pages, media, and
+  components
+---
+
+# Content Management Skill
+
+This skill provides tools for managing content in Acquia Source via JSON:API.
+Use these commands to list, fetch, update, and create pages and other content
+entities.
+
+## Available Commands
+
+All commands use the `@freelygive/canvas-jsonapi` CLI:
+
+```bash
+npx canvas-jsonapi <command> [args...]
+```
+
+### List Content
+
+List content items of a specific type:
+
+```bash
+npx canvas-jsonapi list <type>
+npx canvas-jsonapi list --types  # Discover available types
+```
+
+### Get Content
+
+Fetch one or more content items and save them locally:
+
+```bash
+npx canvas-jsonapi get <type> <uuid> [<uuid>...]
+npx canvas-jsonapi get <type> <uuid> --include <relationships>
+```
+
+Examples:
+
+```bash
+npx canvas-jsonapi get page abc-123-def
+npx canvas-jsonapi get page abc-123 def-456 ghi-789
+npx canvas-jsonapi get media--image uuid1 uuid2 uuid3
+npx canvas-jsonapi get page abc-123-def --include image,owner
+```
+
+Saves content to `content/<type>/<uuid>.json`. For `media--image`, automatically
+includes the file relationship and displays the thumbnail URL and `target_id`.
+
+### Create Content
+
+Create a new content item from a local file:
+
+```bash
+npx canvas-jsonapi create <file-path>
+```
+
+After creation, the temporary file is removed and the full entity is fetched and
+saved with the UUID returned by the API.
+
+### Update Content
+
+Push changes from a local JSON file back to the API:
+
+```bash
+npx canvas-jsonapi update <file-path>
+```
+
+The file must contain valid JSON:API data with `data.type` and `data.id` fields.
+
+### Delete Content
+
+Delete one or more content items:
+
+```bash
+npx canvas-jsonapi delete <type> <uuid> [<uuid>...]
+```
+
+Examples:
+
+```bash
+npx canvas-jsonapi delete page abc-123-def
+npx canvas-jsonapi delete media--image uuid1 uuid2 uuid3
+```
+
+Also removes the local JSON file if it exists.
+
+### Upload Image
+
+Upload an image and create a media entity:
+
+```bash
+npx canvas-jsonapi upload-image <image-path> [alt-text]
+```
+
+Example:
+
+```bash
+npx canvas-jsonapi upload-image src/stories/assets/photo.jpg "Photo description"
+```
+
+Output includes:
+
+- Media UUID
+- File path
+- Thumbnail URL
+- `target_id` for use in components
+
+### Generate UUID
+
+Generate random UUIDs for new components:
+
+```bash
+npx canvas-jsonapi uuid        # Generate 1 UUID
+npx canvas-jsonapi uuid 5      # Generate 5 UUIDs
+```
+
+## Local File Storage
+
+Content is stored in the `/content` directory (gitignored):
+
+```
+content/
+  page/
+    abc-123-def-456.json
+  media--image/
+    img-123-456.json
+```
+
+## Page Structure
+
+Pages in Acquia Source contain these key attributes:
+
+- `title` - Page title
+- `status` - Published status (true/false)
+- `path` - URL path configuration
+- `components` - Array of canvas components
+- `metatags` - SEO metadata
+- `include_in_search` - Whether to index for search
+
+### Canvas Component Structure
+
+Components are stored in `data.attributes.components` as a flat array. Nesting
+is defined via `parent_uuid` and `slot` fields:
+
+```json
+{
+  "data": {
+    "type": "page",
+    "attributes": {
+      "title": "My Page",
+      "status": true,
+      "components": [
+        {
+          "uuid": "comp-001",
+          "component_id": "js.section",
+          "inputs": { "width": "Normal" },
+          "parent_uuid": null,
+          "slot": null
+        },
+        {
+          "uuid": "comp-002",
+          "component_id": "js.heading",
+          "inputs": { "text": "Title", "level": "h2" },
+          "parent_uuid": "comp-001",
+          "slot": "content"
+        }
+      ]
+    }
+  }
+}
+```
+
+Note: `inputs` are automatically parsed to objects when fetched and stringified
+when sent back to the API.
+
+### Component Fields
+
+| Field               | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `uuid`              | Unique identifier for this component instance              |
+| `component_id`      | Component type (e.g., `js.heading`, `js.card`)             |
+| `component_version` | Version hash of the component definition                   |
+| `inputs`            | Object containing prop values                              |
+| `parent_uuid`       | UUID of parent component (null for root-level)             |
+| `slot`              | Slot name in parent (null for root-level, e.g., "content") |
+
+## Media Image Handling
+
+### Uploading Images
+
+Images must be uploaded to the media library before referencing in components:
+
+```bash
+npx canvas-jsonapi upload-image image.jpg "Alt text"
+```
+
+Output:
+
+```
+Uploading: image.jpg
+Uploaded: image.jpg
+  UUID: 98eabd02-c52c-493b-8ca9-cb9d0fe70ceb
+  File: /var/www/html/pages/media--image/98eabd02-...json
+  Thumbnail: https://...
+  target_id: 31
+```
+
+### Media vs File Entity IDs (Critical)
+
+When working with images, there are two different internal IDs:
+
+| Entity Type | ID Location                                   | Usage                      |
+| ----------- | --------------------------------------------- | -------------------------- |
+| **File**    | `drupal_internal__target_id` in relationships | Internal file reference    |
+| **Media**   | `resourceVersion=id%3AXX` in self link URL    | **Use this in components** |
+
+The `target_id` shown in command output is the correct media internal ID.
+
+### Referencing Images in Components
+
+Components that accept images (like `js.card`) use a `target_id` reference:
+
+```json
+{
+  "component_id": "js.card",
+  "inputs": {
+    "heading": "My Card",
+    "image": { "target_id": "31" },
+    "text": { "value": "<p>Content</p>", "format": "canvas_html_block" }
+  }
+}
+```
+
+**Important:** The `target_id` must be the **media entity's internal ID**, not
+the file's internal ID.
+
+### Text Fields with HTML
+
+Rich text fields use a specific format:
+
+```json
+{
+  "text": {
+    "value": "<p>HTML content with <a href=\"/page\">links</a>.</p>",
+    "format": "canvas_html_block"
+  }
+}
+```
+
+### Allowed HTML Elements in Formatted Content
+
+The following HTML elements are supported in formatted editor fields (like
+article body content):
+
+#### Inline Formatting
+
+| Element    | Usage           | Example                      |
+| ---------- | --------------- | ---------------------------- |
+| `<strong>` | Bold text       | `<strong>important</strong>` |
+| `<em>`     | Italic/emphasis | `<em>emphasized</em>`        |
+| `<u>`      | Underlined text | `<u>underlined</u>`          |
+| `<s>`      | Strikethrough   | `<s>deleted</s>`             |
+| `<sup>`    | Superscript     | `x<sup>2</sup>`              |
+| `<sub>`    | Subscript       | `H<sub>2</sub>O`             |
+| `<a>`      | Links           | `<a href="/page">link</a>`   |
+| `<code>`   | Inline code     | `<code>variable</code>`      |
+
+#### Block Elements
+
+| Element         | Usage                       | Example                          |
+| --------------- | --------------------------- | -------------------------------- |
+| `<p>`           | Paragraphs                  | `<p>Text content</p>`            |
+| `<h2>` - `<h6>` | Headings (h2-h6 only)       | `<h2>Section Title</h2>`         |
+| `<ul>`          | Unordered list              | `<ul><li>Item</li></ul>`         |
+| `<ol>`          | Ordered list                | `<ol><li>Step 1</li></ol>`       |
+| `<blockquote>`  | Highlighted external quotes | `<blockquote>Quote</blockquote>` |
+
+#### Text Alignment Classes
+
+Apply alignment via class attribute on block elements:
+
+| Class                 | Effect         |
+| --------------------- | -------------- |
+| `.text-align-center`  | Center aligned |
+| `.text-align-right`   | Right aligned  |
+| `.text-align-justify` | Justified text |
+
+Example:
+
+```html
+<p class="text-align-center">Centered paragraph</p>
+<h2 class="text-align-right">Right-aligned heading</h2>
+```
+
+#### Embedded Media
+
+Media items (images, videos) can be embedded within formatted content using
+Drupal's `<drupal-media>` tag. This allows images to appear inline within
+article body content.
+
+**Format:**
+
+```html
+<drupal-media data-entity-type="media" data-entity-uuid="MEDIA-UUID"
+  >&nbsp;</drupal-media
+>
+```
+
+**Steps to embed an image:**
+
+1. First, upload the image to create a media entity:
+
+   ```bash
+   npx canvas-jsonapi upload-image path/to/image.jpg "Alt text description"
+   ```
+
+   Note the UUID returned (e.g., `c4324a2c-6a1d-43a1-98b5-bb2d73e42c54`).
+
+2. Or find an existing media item:
+
+   ```bash
+   npx canvas-jsonapi list media--image
+   ```
+
+3. Add the `<drupal-media>` tag to the content's `value` field:
+
+   ```json
+   {
+     "content": {
+       "value": "<p>Article text here...</p><drupal-media data-entity-type=\"media\" data-entity-uuid=\"c4324a2c-6a1d-43a1-98b5-bb2d73e42c54\">&nbsp;</drupal-media><p>More text after image...</p>",
+       "format": "filtered_html"
+     }
+   }
+   ```
+
+**Important notes:**
+
+- The `&nbsp;` inside the tag is required (non-breaking space placeholder)
+- Use the media entity's UUID, not the file UUID
+- The `processed` field in the response shows the rendered HTML with actual
+  `<img>` tags - this is read-only and generated by Drupal
+- Only edit the `value` field, never the `processed` field
+
+### Content Formatting Best Practices
+
+1. **Use semantic elements**: Use `<strong>` for important text, `<em>` for
+   emphasis, not just for visual styling.
+
+2. **Blockquotes for highlighted external quotes only**: Use `<blockquote>` only
+   for external quotes that need visual emphasis (e.g., testimonials, key
+   statements from interviews). Do not use for inline quotes within regular
+   paragraphs. Use `<em>` for speaker attribution:
+
+   ```html
+   <blockquote>
+     <p>"Quote text here"</p>
+     <p><em>— Speaker Name, Title</em></p>
+   </blockquote>
+   ```
+
+   For regular inline quotes, simply use quotation marks within a `<p>` tag.
+
+3. **Lists for related items**: Use `<ul>` or `<ol>` when listing multiple items
+   rather than comma-separated text.
+
+4. **Headings for structure**: Use `<h2>`-`<h6>` to create clear content
+   sections.
+
+## Workflow Examples
+
+### Download and Edit a Page
+
+```bash
+npx canvas-jsonapi list page
+npx canvas-jsonapi get page abc-123-def
+# Edit content/page/abc-123-def.json
+npx canvas-jsonapi update content/page/abc-123-def.json
+```
+
+### Create a Page with Images
+
+1. Upload images:
+
+   ```bash
+   npx canvas-jsonapi upload-image image1.jpg "Description"
+   # Note target_id: 31
+   ```
+
+2. Generate UUIDs:
+
+   ```bash
+   npx canvas-jsonapi uuid 3
+   ```
+
+3. Create page JSON at `content/page/new-my-page.json`:
+
+   ```json
+   {
+     "data": {
+       "type": "page",
+       "attributes": {
+         "title": "My Page",
+         "status": true,
+         "components": [
+           {
+             "uuid": "generated-uuid",
+             "component_id": "js.card",
+             "inputs": {
+               "heading": "Card",
+               "image": { "target_id": "31" }
+             },
+             "parent_uuid": null,
+             "slot": null
+           }
+         ],
+         "path": { "alias": "/my-page" },
+         "include_in_search": true
+       }
+     }
+   }
+   ```
+
+4. Create the page:
+
+   ```bash
+   npx canvas-jsonapi create content/page/new-my-page.json
+   ```
+
+## Common Pitfalls
+
+1. **Wrong ID type**: Using file's `drupal_internal__target_id` instead of
+   media's internal ID causes "image.src NULL value found" errors.
+
+2. **Missing langcode permission**: When creating pages, omit the `langcode`
+   field as the API may reject it with permission errors.
+
+3. **Patching limitations**: PATCH requests may not work for all fields. Create
+   a new page with a different alias if updates fail.
+
+## Environment Variables
+
+Required in `.env`:
+
+- `CANVAS_SITE_URL` - Base URL of Acquia Source site
+- `CANVAS_JSONAPI_PREFIX` - API prefix (default: "api")
+- `CANVAS_CLIENT_ID` - OAuth client ID
+- `CANVAS_CLIENT_SECRET` - OAuth client secret

--- a/.agents/skills/full-site-build/SKILL.md
+++ b/.agents/skills/full-site-build/SKILL.md
@@ -1,0 +1,425 @@
+---
+name: full-site-build
+description:
+  End-to-end autonomous pipeline — takes any source URL (or Figma URL), builds
+  all Canvas components AND migrates all structured content in parallel, then
+  assembles the final Canvas pages with real components wired to real content.
+  When source MCP is connected, missing content types and fields are created
+  automatically. If source MCP is absent and types are missing, the pipeline
+  pauses for the user. Triggers on phrases like "full site from URL", "build and
+  migrate", "end to end from URL", "full site build", "build the full site",
+  "build site and migrate content", "do everything end to end".
+metadata:
+  mcp-server: figma, figma-desktop
+allowed-tools: Bash(playwright-cli:*), Bash(npx canvas-jsonapi *), Bash(npm *)
+---
+
+# Full Site Build — End-to-End Pipeline
+
+Builds Canvas components AND migrates structured content from one source URL,
+then assembles Canvas pages that wire the two together. Runs both tracks in
+parallel; only stops at the Content Type Gate if Drupal content types are
+missing.
+
+## Pipeline Overview
+
+```
+Source URL (and/or Figma URL)
+    │
+    ├─── Track A: Component Build ──────────────────────────────────────────┐
+    │      Phase A1 — Capture source into Figma (if web URL)                │
+    │      Phase A2 — Build React components                                │
+    │      Phase A3 — Visual QA loop (mandatory, multi-iteration)           │
+    │      Phase A4 — Validate → Re-QA → Upload                            │
+    │               ├── A4a  Validate (npm run code:fix)                   │
+    │               ├── A4b  Visual QA again ← MANDATORY after validate    │
+    │               └── A4c  Upload to Canvas                              │
+    │                                                                        │
+    ├─── Track B: Content Migration ────────────────────────────────────────┤
+    │      Phase B1 — Discover Canvas site schema (npx canvas-jsonapi)      │
+    │      Phase B2 — Crawl source (Playwright)                             │
+    │      Phase B3 — Content Type Gate                                      │
+    │               ↳ source-mcp connected → auto-create types & fields     │
+    │               ↳ source-mcp absent   → STOP, wait for user             │
+    │      Phase B4 — Create taxonomy terms                                  │
+    │      Phase B5 — Create menu items                                      │
+    │      Phase B6 — Create content nodes                                   │
+    │                                                                        │
+    └─── Merge: Canvas Page Assembly ───────────────────────────────────────┘
+           Phase C — Build Canvas pages: real components + real content
+           Phase D — Verify live Canvas pages
+    │
+    ▼
+Done — final report
+```
+
+Tracks A and B run **concurrently** — start both before waiting on either. Phase
+C (page assembly) only runs after **both** A4 and B6 are complete.
+
+---
+
+## Rules for Autonomous Operation
+
+- **Do not ask clarifying questions** mid-run. Make reasonable decisions and
+  document them in the final report.
+- **Content Type Gate (Phase B3):** If source MCP is connected, auto-create
+  missing content types and fields — no stop needed, proceed straight to B4. If
+  source MCP is NOT connected, output the CT checklist and **STOP** until the
+  user confirms. All other errors: retry up to 3 times, then document and
+  continue.
+- **Max QA iterations per component:** 5. If still failing after 5, mark as
+  "needs manual review" and continue.
+- **Never substitute Canvas `page` for a missing structured content type.**
+- **Phase C is mandatory.** Do not report "done" until Canvas pages exist with
+  components placed and content wired in.
+
+---
+
+## Track A: Component Build
+
+### Phase A1 — Capture to Figma (web URLs only)
+
+Skip this phase if the source is already a `figma.com` URL.
+
+1. Open source URL at 1440×900 via `playwright-cli open --browser=chrome`
+2. Dismiss cookie banners, popups, overlays
+3. Detect page height and sticky header offset
+4. Capture into Figma: `generate_figma_design(outputMode: "newFile")`
+5. Poll until complete, save `fileKey`
+
+### Phase A2 — Build Components
+
+For each visual section of the source:
+
+1. `get_design_context(fileKey, nodeId)` per section
+2. Build React component following `nebula-component-creation` patterns
+3. Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+4. Apply `canvas-component-definition` contract
+5. Apply `canvas-component-metadata` for `component.yml`
+6. Apply `canvas-component-utils` for FormattedText/Image
+7. Create Storybook story per `nebula-storybook-stories`
+
+### Phase A3 — Visual QA Loop (MANDATORY)
+
+> ⛔ Do not skip. One screenshot glance is not QA.
+
+For each component:
+
+1. Start Storybook at `http://localhost:6006` if not running (`npm run dev`)
+2. Screenshot live site section at 1440px (correct Y offset, no overlays)
+3. Extract computed style manifest from live site
+4. Screenshot Storybook story at
+   `http://localhost:6006/iframe.html?id=<id>&viewMode=story` (resize 1440×900)
+5. Extract computed style manifest from Storybook
+6. Compare: layout, typography, colors, spacing — tolerance ≤2px/2%
+7. If any diff → fix `src/components/<name>/index.jsx` → wait 2s → re-compare
+8. Repeat up to 5 iterations. After 5 → mark "needs manual review", move on
+9. Component is "Matched" only when: screenshot AND style manifest both pass
+
+### Phase A4 — Validate & Upload
+
+1. **Validate**
+
+   ```bash
+   npm run code:fix
+   ```
+
+   Fix lint/formatting errors. Retry up to 3 times until passing.
+
+2. **Re-run visual QA after validation** — ESLint/Prettier auto-fix can rewrite
+   JSX in ways that shift visual output. After `code:fix` passes, run the full
+   `visual-qa-loop` again for every component. Only proceed to upload once every
+   component still passes the visual QA check.
+
+   > ⛔ **This QA pass is mandatory.** A clean lint run does not mean the
+   > component still matches the reference. Do not upload until this second QA
+   > pass confirms it.
+
+3. **Upload** — follow `canvas-component-upload` skill (handle dependency
+   ordering, retry on conflict). After all components:
+
+   ```bash
+   npx canvas upload -d ./src/components --css-only -y
+   ```
+
+---
+
+## Track B: Content Migration
+
+### Phase B1 — Discover Canvas Site Schema
+
+```bash
+npx canvas-jsonapi list --types
+```
+
+Record all available types: `node--*`, `taxonomy_term--*`,
+`menu_link_content--menu_link_content`, `page`.
+
+### Phase B2 — Crawl Source (Playwright)
+
+Use Playwright as the default. Do not try WebFetch first — most modern sites
+need JavaScript.
+
+```bash
+playwright-cli open <source-url>
+playwright-cli snapshot
+```
+
+Visit 5–10 representative pages. From each snapshot YAML, extract:
+
+- URL patterns and page titles
+- Nav structure (section names, hierarchy)
+- Content signals: dates, authors, bios, tags, images, download links
+- Repeating patterns (cards, profiles, listings, etc.)
+
+If a Figma URL was also provided: use `get_design_context` to extract the
+content schema (field names, required vs optional, relationships). Figma defines
+the schema; Playwright provides the actual values.
+
+Classify each content pattern into a canonical type derived from what the source
+actually contains (do not hardcode a fixed type list).
+
+### Phase B3 — Content Type Gate
+
+Check classified types against `npx canvas-jsonapi list --types`.
+
+- Type exists → continue to B4
+- Type **missing** → probe source MCP (Step 1 below)
+
+> ⛔ Never create Canvas `page` entities as a substitute for a missing
+> structured content type.
+
+#### Step 1 — Probe source MCP
+
+Call `ListMcpResourcesTool` with `server: "source-mcp"`:
+
+- **Succeeds** → source MCP is connected → **auto-create missing types
+  (Step 2)**
+- **Fails / not connected** → fall back to manual checklist (Step 3)
+
+#### Step 2 — Auto-create via source MCP (source-mcp connected)
+
+For each missing content type:
+
+1. **Create the content type:** Use `create_content_type` with `machine_name`,
+   `label`, `workflow: "editorial"` (default unless another workflow is known),
+   and optional `description`.
+
+2. **Add each custom field:** Use `add_field_to_content_type` — map inferred
+   data to the correct `field_type`:
+
+   | Data from source                | MCP `field_type`                          |
+   | ------------------------------- | ----------------------------------------- |
+   | Short text (title, name, label) | `string`                                  |
+   | Long formatted text (body, bio) | `text_long`                               |
+   | Long text with summary          | `text_with_summary`                       |
+   | Date / time                     | `datetime`                                |
+   | URL / link                      | `link`                                    |
+   | Email address                   | `email`                                   |
+   | True/false toggle               | `boolean`                                 |
+   | Fixed list of text values       | `list_string`                             |
+   | Reference to another node       | `field_ui:entity_reference:node`          |
+   | Reference to taxonomy term      | `field_ui:entity_reference:taxonomy_term` |
+   | Image or file                   | `field_ui:entity_reference:media`         |
+
+3. **Verify JSON:API exposure:** Re-run `npx canvas-jsonapi list --types` to
+   confirm `node--<machine-name>` appears. Retry up to 3 times with a short
+   wait. If still missing, warn the user to expose it at
+   `/admin/config/services/jsonapi/resource_types` and wait for confirmation.
+
+4. **Source MCP limitations** — handle gracefully, do not stop the pipeline:
+   - Cannot create new vocabularies — only vocabularies that already exist on
+     the site can be used (discover them via `ListMcpResourcesTool` or
+     `list_entities` with `entity_type: "taxonomy_vocabulary"`)
+   - Cannot create menus — see Phase B5 for menu handling
+
+Proceed to B4 once all types are confirmed.
+
+#### Step 3 — Manual checklist (source MCP not connected)
+
+Output the following block for each missing type and **STOP**:
+
+---
+
+**⚠ Action required — pipeline paused at content migration.**
+
+Source MCP is not connected. Create the following Drupal content types manually,
+then reply "done" to resume:
+
+1. `/admin/structure/types/add`
+2. Add the fields listed
+3. `/admin/config/services/jsonapi/resource_types` — expose the type
+
+##### Content Type: `<machine-name>`
+
+**Label:** `<Human Readable Name>` **Purpose:** `<what this content represents>`
+**Source URL example:** `<a real URL of this content type>`
+
+| Field label | Machine name | Drupal field type | Required       |
+| ----------- | ------------ | ----------------- | -------------- |
+| Title       | title        | Text (plain)      | Yes (built-in) |
+| ...         | field\_...   | ...               | ...            |
+
+**Expose in JSON:API as:** `node--<machine-name>`
+
+---
+
+Resume Phase B4 only after user confirms all types exist and are
+JSON:API-exposed.
+
+### Phase B4 — Create Taxonomy Terms
+
+**If source MCP is connected:** First discover available vocabularies via
+`list_entities(entity_type: "taxonomy_vocabulary")`, then use
+`get_or_create_term(vid, name)` with the appropriate vocabulary. If content
+requires a vocabulary that doesn't exist on the site, inform the user to create
+it manually at `/admin/structure/taxonomy/add` before resuming.
+
+**If source MCP is NOT connected:** Use `npx canvas-jsonapi create`:
+
+```json
+{
+  "data": {
+    "type": "taxonomy_term--<vocab>",
+    "attributes": { "name": "<Term Name>", "weight": 0 }
+  }
+}
+```
+
+```bash
+npx canvas-jsonapi create content/taxonomy_term--<vocab>/<slug>.json
+```
+
+Record every created UUID — required for node relationships.
+
+### Phase B5 — Create Menu Items
+
+Check `npx canvas-jsonapi list --types` for
+`menu_link_content--menu_link_content`.
+
+- **Not in list:** inform user to create menu items manually at
+  `/admin/structure/menu/manage/main`. Move on.
+- **In list:** create parents first, record UUIDs, then create children with
+  `relationships.parent`.
+
+### Phase B6 — Create Content Nodes
+
+Creation order (dependency-safe):
+
+1. Taxonomy terms (done in B4)
+2. Media/images: `npx canvas-jsonapi upload-image <path> "Alt text"`
+3. Independent nodes (e.g. `person`) — no references to other nodes
+4. Dependent nodes (e.g. `article` referencing `person`) — after step 3
+
+```json
+{
+  "data": {
+    "type": "node--<type>",
+    "attributes": {
+      "title": "<Title>",
+      "status": true,
+      "body": { "value": "<p>HTML</p>", "format": "basic_html", "summary": "" },
+      "path": { "alias": "/<slug>" }
+    },
+    "relationships": {
+      "field_<ref>": { "data": { "type": "<entity-type>", "id": "<uuid>" } }
+    }
+  }
+}
+```
+
+HTML body: only `p strong em a ul ol li h2 h3 h4 blockquote`.
+
+```bash
+npx canvas-jsonapi create content/node--<type>/<slug>.json
+```
+
+---
+
+## Merge: Canvas Page Assembly
+
+Run Phase C only after **both** A4 (components uploaded) and B6 (nodes created)
+are complete.
+
+### Phase C — Build Canvas Pages
+
+Canvas `page` entities are layout containers only — not content stores. Use them
+for: homepage, section landing pages (e.g. /academics, /news), utility pages
+(404).
+
+For each page, wire the uploaded components with real content from B6:
+
+```json
+{
+  "data": {
+    "type": "page",
+    "attributes": {
+      "title": "<Page Title>",
+      "status": true,
+      "path": { "alias": "/<path>" },
+      "components": [
+        {
+          "uuid": "<uuid>",
+          "component_id": "js.<machine_name>",
+          "component_version": "<version-hash>",
+          "inputs": { "<prop>": "<real value from crawled content>" },
+          "parent_uuid": null,
+          "slot": null,
+          "label": null
+        }
+      ]
+    }
+  }
+}
+```
+
+```bash
+npx canvas-jsonapi create content/page/new-<slug>.json
+```
+
+Component version hash: `GET /canvas/api/v0/config/js_component/<name>` →
+extract 16-char hex from the `js_header` field.
+
+### Phase D — Verify Live Pages
+
+Open each assembled Canvas page in playwright-cli. Screenshot and compare
+against the source URL screenshot from A1. Note structural differences in the
+final report.
+
+---
+
+## Final Report
+
+```
+## Full Site Build — Summary
+
+**Source:** <URL>
+**Canvas site:** <CANVAS_SITE_URL>
+
+### Track A: Components
+| Component | Built | QA Iterations | QA Status | Uploaded |
+|-----------|-------|--------------|-----------|---------|
+| hero      | ✅    | 2            | ✅ Matched | ✅      |
+| ...       |       |              |           |         |
+
+### Track B: Content
+| Step | Status | Count |
+|------|--------|-------|
+| Canvas schema discovered | ✅ | N types available |
+| Content types confirmed | ✅ / ⚠ pending | N missing |
+| Taxonomy terms created | ✅ | N terms |
+| Menu items created | ✅ / manual | N items |
+| Content nodes created | ✅ | N nodes |
+
+### Canvas Pages Assembled
+| Page | URL | Status |
+|------|-----|--------|
+| Homepage | / | ✅ live |
+| ...      |   |        |
+
+### Notes
+- <autonomous decisions made>
+- <components needing manual review>
+- <content types that were missing and required user action>
+- <any errors and how resolved>
+```

--- a/.agents/skills/nebula-component-creation/SKILL.md
+++ b/.agents/skills/nebula-component-creation/SKILL.md
@@ -13,6 +13,27 @@ for story naming, structure, and CSF details).
 
 ## Workflow
 
+### Static vs. dynamic components — decide before building
+
+Before writing any code, classify the component:
+
+| Type        | Signals                                                                                                                   | Approach                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Static**  | Single fixed section — hero, navbar, footer, page hero, CTA banner                                                        | Build with props; expose scalar values in `component.yml`                                                                  |
+| **Dynamic** | Repeating collection of content entities — news cards, article listing, brands carousel, FAQ accordion, testimonials grid | Use SWR + `canvas-data-fetching`; do **not** accept a list prop; do **not** hardcode list defaults as the real data source |
+
+**For dynamic components:**
+
+- Wire data fetching with `JsonApiClient` + `useSWR` from the appropriate
+  `node--<type>` endpoint
+- Map CT field names to render props (strip `field_` prefix, camelCase the rest:
+  `field_read_time` → `readTime`)
+- Fetch filter options (taxonomy terms, categories) dynamically — never hardcode
+  them
+- Storybook story shows a loading/empty state, not mocked list data
+- Do **not** expose the list as a `component.yml` prop — Canvas editors set
+  scalar config only (heading, CTA label, etc.)
+
 ### Creating a new component
 
 Always start from an example. When asked to create a new component:

--- a/.agents/skills/nebula-component-validation/SKILL.md
+++ b/.agents/skills/nebula-component-validation/SKILL.md
@@ -27,3 +27,14 @@ This runs Prettier and ESLint with auto-fix, ensuring:
 - Drupal Canvas Code Component requirements
 
 If errors remain after auto-fix, address them manually and re-run until passing.
+
+## Post-validation visual QA (mandatory)
+
+After `code:fix` passes, always run the `visual-qa-loop` again for every
+component that was validated. ESLint/Prettier auto-fix can rewrite JSX
+formatting in ways that shift visual output. A clean lint run does **not** mean
+the component still matches the design reference — you must confirm visually.
+
+> ⛔ **Never consider validation complete until the post-validation QA pass
+> confirms the component still matches the reference.** Upload only happens
+> after this second QA pass.

--- a/.agents/skills/playwright-cli/SKILL.md
+++ b/.agents/skills/playwright-cli/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: playwright-cli
+description:
+  Automates browser interactions for web testing, form filling, screenshots, and
+  data extraction. Use when the user needs to navigate websites, interact with
+  web pages, fill forms, take screenshots, test web applications, or extract
+  information from web pages.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+playwright-cli fill e5 "user@example.com"
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli snapshot --filename=after-click.yaml
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start
+playwright-cli video-stop video.webm
+```
+
+## Open parameters
+
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+# Connect to browser via extension
+playwright-cli open --extension
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser
+state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command.
+
+If `--filename` is not provided, a new snapshot file is created with a
+timestamp. Default to automatic file naming, use `--filename=` when artifact is
+a part of the workflow result.
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Local installation
+
+In some cases user might want to install playwright-cli locally. If running
+globally available `playwright-cli` binary fails, use `npx playwright-cli` to
+run the commands. For example:
+
+```bash
+npx playwright-cli open https://example.com
+npx playwright-cli click e1
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+- **Request mocking**
+  [references/request-mocking.md](references/request-mocking.md)
+- **Running Playwright code**
+  [references/running-code.md](references/running-code.md)
+- **Browser session management**
+  [references/session-management.md](references/session-management.md)
+- **Storage state (cookies, localStorage)**
+  [references/storage-state.md](references/storage-state.md)
+- **Test generation**
+  [references/test-generation.md](references/test-generation.md)
+- **Tracing** [references/tracing.md](references/tracing.md)
+- **Video recording**
+  [references/video-recording.md](references/video-recording.md)

--- a/.agents/skills/playwright-cli/references/request-mocking.md
+++ b/.agents/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,88 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or
+delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.agents/skills/playwright-cli/references/running-code.md
+++ b/.agents/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,233 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not
+covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading', { state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.maybe-missing', { timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.agents/skills/playwright-cli/references/session-management.md
+++ b/.agents/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,171 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on
+`open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.agents/skills/playwright-cli/references/storage-state.md
+++ b/.agents/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,276 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive
+  operations

--- a/.agents/skills/playwright-cli/references/test-generation.md
+++ b/.agents/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,91 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding
+Playwright TypeScript code. This code appears in the output and can be copied
+directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { expect, test } from "@playwright/test";
+
+test("login flow", async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto("https://example.com/login");
+  await page.getByRole("textbox", { name: "Email" }).fill("user@example.com");
+  await page.getByRole("textbox", { name: "Password" }).fill("password123");
+  await page.getByRole("button", { name: "Sign In" }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more
+resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole("button", { name: "Submit" }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator("#submit-btn").click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your
+test:
+
+```typescript
+// Generated action
+await page.getByRole("button", { name: "Submit" }).click();
+
+// Manual assertion
+await expect(page.getByText("Success")).toBeVisible();
+```

--- a/.agents/skills/playwright-cli/references/tracing.md
+++ b/.agents/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,144 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM
+snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several
+files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category        | Details                                            |
+| --------------- | -------------------------------------------------- |
+| **Actions**     | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM**         | Full DOM snapshot before/after each action         |
+| **Screenshots** | Visual state at each step                          |
+| **Network**     | All requests, responses, headers, bodies, timing   |
+| **Console**     | All console.log, warn, error messages              |
+| **Timing**      | Precise timing for each operation                  |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature                 | Trace       | Video       | Screenshot       |
+| ----------------------- | ----------- | ----------- | ---------------- |
+| **Format**              | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection**      | Yes         | No          | No               |
+| **Network details**     | Yes         | No          | No               |
+| **Step-by-step replay** | Yes         | Continuous  | Single frame     |
+| **File size**           | Medium      | Large       | Small            |
+| **Best for**            | Debugging   | Demos       | Quick capture    |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.agents/skills/playwright-cli/references/video-recording.md
+++ b/.agents/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,44 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or
+verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+playwright-cli video-stop recordings/checkout-test-run-42.webm
+```
+
+## Tracing vs Video
+
+| Feature  | Video                | Tracing                                  |
+| -------- | -------------------- | ---------------------------------------- |
+| Output   | WebM file            | Trace file (viewable in Trace Viewer)    |
+| Shows    | Visual recording     | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis                      |
+| Size     | Larger               | Smaller                                  |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.agents/skills/site-content-migration/SKILL.md
+++ b/.agents/skills/site-content-migration/SKILL.md
@@ -1,0 +1,557 @@
+---
+name: site-content-migration
+description:
+  Migrate structured content (menus, taxonomy, nodes) from any source into a
+  Canvas/Drupal site using JSON:API — no module installation required. The
+  source can be a live website URL (crawled with Playwright) or a Figma design
+  file (analyzed with the Figma MCP). Claude classifies content, infers the
+  required Drupal content type schema, and creates all entities via npx
+  canvas-jsonapi. Use when building a new Canvas site from an existing web
+  source or design. Triggered by phrases like "migrate content from URL",
+  "migrate content from Figma", "set up content structure from site", "import
+  content types from URL/design", or "migrate site content".
+allowed-tools: Bash(playwright-cli:*), Bash(npx canvas-jsonapi *)
+---
+
+# Site Content Migration Skill
+
+Migrates structured content from any source into Canvas/Drupal using
+**Playwright + Figma MCP + JSON:API**. No Drupal module installation needed.
+
+The source can be:
+
+- **A live website URL** — crawled with Playwright to extract real content
+- **A Figma design file** — analyzed with the Figma MCP to extract the content
+  schema from the design's components and annotations
+- **Both** — Figma defines the schema; the live site provides the actual data
+
+Claude does the analysis; `npx canvas-jsonapi` does the writing.
+
+---
+
+## Analysis Toolkit
+
+| Tool                              | Best for                                   | Limitation                                 |
+| --------------------------------- | ------------------------------------------ | ------------------------------------------ |
+| **Playwright** (`playwright-cli`) | Any live website — default choice          | Higher token cost (~5–30k tokens/page)     |
+| **WebFetch** (built-in)           | Known static CMS (Drupal/WordPress) only   | No JavaScript — fails on most modern sites |
+| **Figma MCP**                     | Schema extraction from design files        | No actual content values                   |
+| **Claude analysis**               | Classifying content, inferring field types | Only as good as the input                  |
+
+**Default: always use Playwright.** Most modern sites use JavaScript for
+rendering. WebFetch only saves tokens if it succeeds — if the site needs JS
+(increasingly common), using WebFetch first wastes tokens on a failed attempt
+before switching to Playwright anyway. Use WebFetch only as an optional
+quick-check when you have prior knowledge the site is fully server-rendered.
+
+---
+
+## Input Detection
+
+Before starting, identify what the user has provided:
+
+| Input                      | Detection         | Analysis method                                  |
+| -------------------------- | ----------------- | ------------------------------------------------ |
+| `figma.com/design/...` URL | Figma design link | Figma MCP (`get_design_context`, `get_metadata`) |
+| `figma.com/board/...` URL  | FigJam board      | Figma MCP (`get_figjam`)                         |
+| Any other URL              | Live website      | Playwright (`playwright-cli`) — default          |
+| Both Figma + live URL      | Design + content  | Figma for schema, Playwright for data            |
+
+If only a Figma URL is given with no live site, phases 2b–2d use design analysis
+only and produce a content schema + CT checklist. Actual node creation (Phase 6)
+is deferred until the user provides real content data.
+
+---
+
+## Pipeline Overview
+
+```
+Source (URL and/or Figma link)
+    │
+    ▼
+Phase 1 — Discover Canvas site schema
+  What content types, vocabularies, and menus already exist?
+    │
+    ▼
+Phase 2 — Analyze source
+  Live URL → Playwright crawl
+  Figma URL → Figma MCP analysis
+  Both → merge findings
+    │
+    ▼
+Phase 3 — Content Type Gate
+  Compare classified content against available types.
+  source-mcp connected → auto-create missing types & fields, continue
+  source-mcp absent + types missing → output checklist, STOP until user confirms
+  Do NOT create Canvas pages as a substitute for missing content types.
+    │
+    ▼
+Phase 4 — Create taxonomy terms
+  Map discovered categories/tags → create taxonomy_term entities via JSON:API
+    │
+    ▼
+Phase 5 — Create menu items
+  Extract nav structure → create menu_link_content entities via JSON:API
+    │
+    ▼
+Phase 6 — Create content nodes
+  Create nodes of the correct type for each piece of content
+    │
+    ▼
+Phase 7 — Create Canvas pages
+  Build layout pages that compose uploaded components with real content
+    │
+    ▼
+Done — report summary
+```
+
+---
+
+## Phase 1: Discover Canvas Site Schema
+
+```bash
+npx canvas-jsonapi list --types
+```
+
+Record every available type. Types that matter:
+
+- `node--*` — writable content node types (e.g. `node--article`, `node--person`)
+- `taxonomy_term--*` — taxonomy vocabularies
+- `menu_link_content--menu_link_content` — menu links (may not be exposed)
+- `page` — Canvas layout page (always present)
+
+---
+
+## Phase 2: Analyze Source
+
+### 2a — Live website (Playwright)
+
+Use Playwright for all live website crawls. Do not attempt WebFetch first — most
+modern sites use JavaScript and WebFetch would return skeleton HTML, wasting
+tokens before you switch to Playwright anyway.
+
+```bash
+playwright-cli open <source-url>
+playwright-cli snapshot
+# Read the snapshot YAML file to extract nav links
+# Do NOT use playwright-cli eval with arrow functions — it fails serialization
+```
+
+Visit 5–10 representative pages. After each snapshot, read the YAML and extract:
+
+- Page title and URL pattern
+- Nav links (reveals site structure and section names)
+- Presence of dates, author bylines, tags, bios, images, download links
+- Repeating structural patterns (cards, profiles, news items, etc.)
+
+**When WebFetch is acceptable (optional token saving):** Only if you have
+confirmed prior knowledge that the source site is a fully server-rendered CMS
+(classic Drupal/WordPress with no JS framework). In that case, use WebFetch to
+fetch a few representative URLs and read the returned markdown directly. If the
+response body is thin (< ~200 words of meaningful content), immediately open
+Playwright without asking the user — do not report the WebFetch failure.
+
+### 2b — Figma design file (Figma MCP)
+
+If the user provides a `figma.com` URL, use the Figma MCP to analyze it.
+
+**Step 1 — get the top-level structure:**
+
+```
+get_metadata(fileKey, nodeId)   ← use nodeId "0:1" for the root/page overview
+```
+
+Identify pages and frames that represent distinct content types (e.g. an
+"Article Detail" frame, a "Faculty Profile" frame, a "Programs" listing frame).
+
+**Step 2 — get design context for each content frame:**
+
+```
+get_design_context(fileKey, nodeId)   ← run for each content-type frame
+```
+
+From the returned code and screenshot, extract:
+
+- What data fields are rendered (title, date, author, bio, image, tags, etc.)
+- What is required vs optional (shown on all variants vs only some)
+- What relationships exist (e.g. article references a person as author)
+
+**Step 3 — check for Code Connect mappings:**
+
+```
+get_code_connect_map(fileKey, nodeId)
+```
+
+If components are already mapped to code, use the component names and props to
+confirm field names.
+
+**What Figma tells you vs what it doesn't:** | Figma can reveal | Figma cannot
+reveal | |-----------------|---------------------| | Content type schema
+(fields, types) | Actual content data | | Required vs optional fields | Real
+taxonomy terms | | Relationships between types | Actual node counts or IDs | |
+URL/path structure (from annotations) | Whether a live site exists |
+
+When only a Figma file is provided (no live URL), proceed through Phase 3 (CT
+checklist) and Phase 4 (taxonomy), but **skip Phase 6** (node creation) and note
+that the user must supply real content data before nodes can be created.
+
+### 2c — Both Figma + live URL
+
+Use Figma for schema definition (field names, types, relationships), and
+Playwright for harvesting the actual content data to populate nodes. Figma takes
+precedence for field naming if there is ambiguity.
+
+### 2d. Classify content into types
+
+For each distinct content pattern found, determine the canonical content type.
+Use the source as the guide — what repeating entity types exist?
+
+Common patterns (examples only — always derive from actual source):
+
+| Source signals                               | Canonical type | Key fields                                                             |
+| -------------------------------------------- | -------------- | ---------------------------------------------------------------------- |
+| Date + author/byline, news/blog section      | `article`      | title, body, date, author, category, image                             |
+| Name + bio + role/title, people/team section | `person`       | title, first_name, last_name, job_title, department, bio, photo, email |
+| Program/service/offering with description    | `service_area` | title, body, key_capabilities, image                                   |
+| Date + location + registration               | `event`        | title, body, date, end_date, location, registration_url, image         |
+| Downloadable file or guide                   | `resource`     | title, body, file, resource_type                                       |
+| General informational/landing page           | `page`         | title, body, image                                                     |
+| Question + answer pairs                      | `faq`          | title, question, answer, category                                      |
+
+These are **examples only**. Never hardcode this list as the output — always
+derive types from what the source actually contains.
+
+---
+
+## Phase 3: Content Type Gate
+
+After classifying content, check which required types already exist:
+
+```bash
+npx canvas-jsonapi list --types
+```
+
+For each classified content pattern:
+
+- If the matching `node--<type>` is in the list → proceed to Phase 4
+- If it is **not** in the list → probe source MCP (Step 1 below)
+
+**Rules:**
+
+1. **Never create Canvas `page` entities as a substitute for a missing
+   structured content type.** Canvas pages are for layout composition only.
+2. **Never hardcode a fixed set of content types.** Always derive what is needed
+   from the source site analysis.
+3. **Output one checklist entry per missing type**, with fields inferred from
+   the source content — not from a template.
+
+### Step 1 — Probe source MCP
+
+Call `ListMcpResourcesTool` with `server: "source-mcp"`:
+
+- **Succeeds** → source MCP is connected → **auto-create missing types
+  (Step 2)**
+- **Fails / not connected** → fall back to manual checklist (Step 3)
+
+### Step 2 — Auto-create via source MCP (source-mcp connected)
+
+For each missing content type:
+
+1. **Name the type** using a machine-name-safe slug (e.g. `article`, `person`,
+   `event`, `program`, `case_study`).
+
+2. **Create the content type:** Use `create_content_type` with `machine_name`,
+   `label`, `workflow: "editorial"` (default unless another workflow is known),
+   and optional `description`.
+
+3. **Add each custom field:** Use `add_field_to_content_type` — map inferred
+   data to the correct `field_type`:
+
+   | Data from source                | MCP `field_type`                          |
+   | ------------------------------- | ----------------------------------------- |
+   | Short text (title, name, label) | `string`                                  |
+   | Long formatted text (body, bio) | `text_long`                               |
+   | Long text with summary          | `text_with_summary`                       |
+   | Date / time                     | `datetime`                                |
+   | URL / link                      | `link`                                    |
+   | Email address                   | `email`                                   |
+   | True/false toggle               | `boolean`                                 |
+   | Fixed list of text values       | `list_string`                             |
+   | Reference to another node       | `field_ui:entity_reference:node`          |
+   | Reference to taxonomy term      | `field_ui:entity_reference:taxonomy_term` |
+   | Image or file                   | `field_ui:entity_reference:media`         |
+
+4. **Verify JSON:API exposure:** Re-run `npx canvas-jsonapi list --types` to
+   confirm `node--<machine-name>` appears. Retry up to 3 times with a short
+   wait. If still missing, warn the user to expose it at
+   `/admin/config/services/jsonapi/resource_types` and wait for confirmation.
+
+5. **Source MCP limitations** — handle gracefully, do not stop the pipeline:
+   - Cannot create new vocabularies — only vocabularies that already exist on
+     the site can be used (discover them via `ListMcpResourcesTool` or
+     `list_entities` with `entity_type: "taxonomy_vocabulary"`)
+   - Cannot create menus — see Phase 5 for menu handling
+
+Proceed to Phase 4 once all types are confirmed.
+
+### Step 3 — Manual checklist (source MCP not connected)
+
+Output the following block for each missing type and **STOP**:
+
+---
+
+**⚠ Action required: content migration is paused.**
+
+Source MCP is not connected. Create the following Drupal content types manually,
+then reply "done" to resume:
+
+1. Go to `/admin/structure/types/add`
+2. Add the fields listed
+3. Go to `/admin/config/services/jsonapi/resource_types` and expose the type
+4. Reply "done" and migration will resume
+
+---
+
+### How to generate the Content Type Checklist (for Step 3)
+
+For each missing type, Claude must:
+
+1. **Name the type** using a machine-name-safe slug derived from the content
+   (e.g. `article`, `person`, `event`, `program`, `case_study`).
+2. **List the fields** by reading actual content from the source pages — what
+   data is displayed? Each visible piece of data is a field.
+3. **Choose the right Drupal field type** for each field:
+
+   | Data                                         | Drupal field type                                 |
+   | -------------------------------------------- | ------------------------------------------------- |
+   | Short text (title, name, label)              | Text (plain)                                      |
+   | Long formatted text (body, bio, description) | Text (formatted, long, with summary)              |
+   | Date/time                                    | Date                                              |
+   | URL / link                                   | Link                                              |
+   | Email address                                | Email                                             |
+   | True/false toggle                            | Boolean                                           |
+   | One value from a fixed list                  | List (text)                                       |
+   | Reference to another node                    | Entity reference → node                           |
+   | Reference to a taxonomy term                 | Entity reference → taxonomy_term                  |
+   | Image or file                                | Entity reference → media--image / media--document |
+
+4. **Mark required fields** — fields that every item of that type must have.
+
+#### Content Type Checklist output format
+
+#### Content Type: `<machine-name>`
+
+**Label:** `<Human Readable Name>` **Purpose:**
+`<one sentence — what this content represents on the source site>` **Source URL
+example:** `<url of a page that is this content type>`
+
+Fields to add:
+
+| Field label | Machine name | Drupal field type | Required       |
+| ----------- | ------------ | ----------------- | -------------- |
+| Title       | title        | Text (plain)      | Yes (built-in) |
+| ...         | field\_...   | ...               | ...            |
+
+**Expose in JSON:API as:** `node--<machine-name>`
+
+---
+
+Only list types that are genuinely needed based on what was found in the crawl.
+Do not output types that have no source content.
+
+---
+
+## Phase 4: Create Taxonomy Terms
+
+After all required content types are confirmed, create taxonomy terms.
+
+Discover taxonomies from source content: category filters, tag clouds, topic
+labels, department names, etc.
+
+**If source MCP is connected:** First discover available vocabularies via
+`list_entities(entity_type: "taxonomy_vocabulary")`, then use
+`get_or_create_term(vid, name)` with the appropriate vocabulary. If content
+requires a vocabulary that doesn't exist on the site, inform the user to create
+it manually at `/admin/structure/taxonomy/add` before resuming.
+
+**If source MCP is NOT connected:** Use `npx canvas-jsonapi create`:
+
+```json
+{
+  "data": {
+    "type": "taxonomy_term--<vocab>",
+    "attributes": {
+      "name": "<Term Name>",
+      "description": { "value": "<optional>", "format": "plain_text" },
+      "weight": 0
+    }
+  }
+}
+```
+
+```bash
+npx canvas-jsonapi create content/taxonomy_term--<vocab>/<term-slug>.json
+```
+
+Record each created term's UUID — needed for node relationship fields.
+
+---
+
+## Phase 5: Create Menu Items
+
+Check if `menu_link_content--menu_link_content` is in
+`npx canvas-jsonapi list --types`. If not, this type is not exposed on this
+Canvas site — inform the user to create menu items manually at
+`/admin/structure/menu/manage/main` and move on.
+
+If the type IS available:
+
+```json
+{
+  "data": {
+    "type": "menu_link_content--menu_link_content",
+    "attributes": {
+      "title": "<Label>",
+      "link": { "uri": "internal:/<path>", "options": [] },
+      "menu_name": "main",
+      "weight": 0,
+      "enabled": true,
+      "expanded": false
+    }
+  }
+}
+```
+
+For sub-menu items, create parents first and reference their UUID via
+`relationships.parent`.
+
+---
+
+## Phase 6: Create Content Nodes
+
+Only run after all required types appear in `npx canvas-jsonapi list --types`.
+
+### General node format
+
+```json
+{
+  "data": {
+    "type": "node--<type>",
+    "attributes": {
+      "title": "<Title>",
+      "status": true,
+      "body": {
+        "value": "<p>HTML body</p>",
+        "format": "basic_html",
+        "summary": "<plain text summary>"
+      },
+      "field_<name>": "<value>",
+      "path": { "alias": "/<url-path>" }
+    },
+    "relationships": {
+      "field_<ref_field>": {
+        "data": { "type": "<entity-type>", "id": "<uuid>" }
+      }
+    }
+  }
+}
+```
+
+### Pre-creation checklist
+
+- [ ] All required types confirmed in `npx canvas-jsonapi list --types`
+- [ ] Taxonomy terms created and UUIDs recorded
+- [ ] Images uploaded: `npx canvas-jsonapi upload-image <path> "Alt text"`
+- [ ] UUIDs generated: `npx canvas-jsonapi uuid`
+
+### Creation order (dependency-safe)
+
+1. Taxonomy terms — no dependencies
+2. Media (images, documents) — no dependencies
+3. Independent nodes (e.g. `person`) — referenced by others
+4. Dependent nodes (e.g. `article` referencing `person`) — after step 3
+5. Canvas layout pages — after all nodes exist
+
+```bash
+npx canvas-jsonapi create content/node--<type>/<slug>.json
+```
+
+HTML body content rules: only use `p strong em a ul ol li h2 h3 h4 blockquote`.
+
+---
+
+## Phase 7: Create Canvas Pages
+
+Canvas pages (`page` type) are layout containers that compose uploaded
+components. They are **not** a content store.
+
+Use `page` only for:
+
+- Section landing pages (e.g. /academics, /news)
+- Homepage
+- Utility pages (404, access denied)
+
+Each page references Canvas components with real data in `inputs`:
+
+```json
+{
+  "data": {
+    "type": "page",
+    "attributes": {
+      "title": "<Page Title>",
+      "status": true,
+      "path": { "alias": "/<path>" },
+      "components": [
+        {
+          "uuid": "<uuid>",
+          "component_id": "js.<machine_name>",
+          "component_version": "<version-hash>",
+          "inputs": { "<prop>": "<value>" },
+          "parent_uuid": null,
+          "slot": null,
+          "label": null
+        }
+      ]
+    }
+  }
+}
+```
+
+```bash
+npx canvas-jsonapi create content/page/new-<slug>.json
+```
+
+---
+
+## Common Pitfalls
+
+1. **Missing content type — do not fall back to `page`**: If source MCP is
+   connected, auto-create the type via `create_content_type` +
+   `add_field_to_content_type`. If not connected, output the Content Type
+   Checklist and pause. Resume only after the user confirms types exist in
+   JSON:API.
+
+2. **`menu_link_content` not in types list**: Not exposed on this Canvas site.
+   Ask the user to create menu items manually at
+   `/admin/structure/menu/manage/main`.
+
+3. **`eval` with arrow functions fails in playwright-cli**: Use `snapshot`
+   instead, then read the generated YAML file to extract content.
+
+4. **Path alias silently ignored**: After creating a node, verify the alias was
+   applied. If not, ask the user to set it in the Drupal UI.
+
+5. **Taxonomy references before terms exist**: Always create taxonomy terms
+   first and record UUIDs before creating nodes that reference them.
+
+6. **Hardcoding content types**: Never assume which types are needed. Always
+   derive them from the actual source analysis (crawl or Figma).
+
+7. **Figma-only with no content data**: When only a Figma file is provided,
+   produce the CT checklist and taxonomy plan but skip node creation (Phase 6).
+   Note clearly that real content data is needed before nodes can be created.
+
+8. **Figma annotations vs real fields**: Figma frames may show placeholder text
+   ("Lorem ipsum", "John Doe"). Do not treat placeholder values as real content
+   — they define the field structure only. Real values come from the live site
+   crawl or user-supplied data.

--- a/.agents/skills/visual-qa-loop/SKILL.md
+++ b/.agents/skills/visual-qa-loop/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: visual-qa-loop
+description:
+  Autonomous visual QA loop that verifies built Canvas components match their
+  design reference, iterates until they do, then validates and uploads to
+  Canvas. Use after components are built and Storybook stories exist. Triggers
+  when the user says "check if it matches", "verify visually", "qa the
+  components", "does it match the design", or after a build step to close the
+  loop automatically. Requires Figma MCP and playwright-cli.
+metadata:
+  mcp-server: figma, figma-desktop
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Visual QA Loop
+
+An autonomous loop that screenshots each component in Storybook, compares it
+against the design reference, fixes any gaps, and repeats until parity is
+reached — then validates and uploads to Canvas.
+
+## MANDATORY CHECKLIST
+
+> ⛔ A component is **NOT** considered "matched" until ALL of the following are
+> done for it. Do not skip any item, even if it "looks fine":
+>
+> - [ ] Reference screenshot taken from live site at correct scroll position
+> - [ ] Style manifest extracted from live site (Step 3B-extra)
+> - [ ] Storybook story screenshotted at 1440×900
+> - [ ] Style manifest extracted from Storybook story (Step 5.2)
+> - [ ] Screenshot comparison completed (Step 5.1)
+> - [ ] Numeric style manifest diff completed (Step 5.2) — every mismatch > 2px
+>       is a discrepancy that must be fixed
+> - [ ] At least one full fix-and-recheck iteration performed if ANY discrepancy
+>       was found
+>
+> Declaring "matched" after only a screenshot glance is **not acceptable**.
+
+## Reference Source
+
+Determine the reference type from how the build was initiated:
+
+- **Figma URL was provided** → use `get_screenshot` from the Figma MCP for each
+  component's node
+- **Live site URL was provided** → use playwright-cli to screenshot the
+  corresponding section of the live page
+
+Keep the reference screenshot(s) accessible throughout the loop. They are the
+source of truth.
+
+---
+
+## Step 1: Ensure Storybook Is Running
+
+Check if Storybook is already running:
+
+```bash
+playwright-cli open http://localhost:6006
+```
+
+If the page doesn't load, start Storybook in the background:
+
+```bash
+npm run dev
+```
+
+Wait until `http://localhost:6006` responds before continuing.
+
+---
+
+## Step 2: Identify Components and Their Stories
+
+For each component being QA'd:
+
+1. Locate the story file at `src/stories/<component_name>.stories.jsx`
+2. Read the file to find the exported story names (e.g., `Default`,
+   `WithoutButton`)
+3. Derive the Storybook story ID:
+   - Take the `title` value (e.g., `"Components/Hero Banner"`)
+   - Lowercase and hyphenate: `components-hero-banner`
+   - Append the story export name lowercased and hyphenated: `--default`
+   - Full ID: `components-hero-banner--default`
+4. The clean preview URL (no Storybook chrome):
+   `http://localhost:6006/iframe.html?id=<story-id>&viewMode=story`
+
+---
+
+## Step 3: Get the Reference Screenshot and Styles
+
+### Option A — Figma reference
+
+For each component node that was used during the build:
+
+```
+get_screenshot(fileKey=":fileKey", nodeId=":nodeId")
+```
+
+If you have a page-level Figma node, get the full page screenshot and crop
+mentally to the relevant section during comparison.
+
+### Option B — Live site reference
+
+Open the live site at 1440px width and screenshot the section that corresponds
+to the component:
+
+```bash
+playwright-cli open <live-site-url> --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli eval "window.scrollTo(0, <scrollY-of-section>)"
+playwright-cli screenshot --filename=reference-<component-name>.png
+```
+
+Store the filename for use in comparison.
+
+### 3B-extra — Extract computed styles from the live site (MANDATORY)
+
+> ⛔ Do not skip this step. A screenshot alone is not sufficient for QA. You
+> must extract and save the style manifest so it can be diffed against Storybook
+> in Step 5.2.
+
+After taking the screenshot, extract the computed styles for the key elements in
+each section. Identify the most important selectors (heading, body text, button,
+container, card) and run:
+
+```bash
+playwright-cli eval "
+const results = {};
+const targets = {
+  heading: 'h1, h2, [class*=\"heading\"], [class*=\"title\"]',
+  body: 'p, [class*=\"body\"], [class*=\"text\"]',
+  button: 'a[class*=\"btn\"], button, a[class*=\"button\"]',
+  nav: 'nav a, [class*=\"nav\"] a',
+  card: '[class*=\"card\"]',
+  container: '[class*=\"container\"], main > div',
+};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  results[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    paddingTop: s.paddingTop,
+    paddingBottom: s.paddingBottom,
+    paddingLeft: s.paddingLeft,
+    paddingRight: s.paddingRight,
+    marginTop: s.marginTop,
+    marginBottom: s.marginBottom,
+    borderRadius: s.borderRadius,
+    textTransform: s.textTransform,
+  };
+}
+JSON.stringify(results, null, 2)
+"
+```
+
+Save this output as your **style manifest** for this component. Reference it
+during comparison to catch exact numeric mismatches.
+
+Also extract the color palette used:
+
+```bash
+playwright-cli eval "
+const colors = new Set();
+document.querySelectorAll('*').forEach(el => {
+  const s = getComputedStyle(el);
+  if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)' && s.backgroundColor !== 'transparent')
+    colors.add(s.backgroundColor);
+  if (s.color) colors.add(s.color);
+});
+JSON.stringify([...colors].slice(0, 30))
+"
+```
+
+---
+
+## Step 4: Screenshot the Storybook Story
+
+```bash
+playwright-cli open http://localhost:6006/iframe.html?id=<story-id>&viewMode=story --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli screenshot --filename=storybook-<component-name>.png
+```
+
+---
+
+## Step 5: Visual Comparison
+
+### 5.1 — Screenshot comparison
+
+Look at both screenshots side by side and evaluate:
+
+- **Layout**: alignment, spacing, padding, margins
+- **Typography**: font family, size, weight, line height, color
+- **Colors**: backgrounds, text, borders, shadows
+- **Components**: icons, images, buttons, badges
+- **Responsiveness**: does it look right at 1440px?
+
+### 5.2 — Style manifest comparison (live site only)
+
+If a style manifest was collected in Step 3B-extra, also extract computed styles
+from the Storybook story to compare numerically:
+
+```bash
+playwright-cli open http://localhost:6006/iframe.html?id=<story-id>&viewMode=story --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli eval "
+const results = {};
+const targets = {
+  heading: 'h1, h2, [class*=\"heading\"], [class*=\"title\"]',
+  body: 'p, [class*=\"body\"]',
+  button: 'a, button',
+  card: '[class*=\"card\"]',
+  container: 'div > div',
+};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  results[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    paddingTop: s.paddingTop,
+    paddingBottom: s.paddingBottom,
+    paddingLeft: s.paddingLeft,
+    paddingRight: s.paddingRight,
+    borderRadius: s.borderRadius,
+    textTransform: s.textTransform,
+  };
+}
+JSON.stringify(results, null, 2)
+"
+```
+
+Diff the two style manifests value-by-value. Every numeric mismatch (font-size,
+padding, line-height, color) is a discrepancy to fix — even if the screenshot
+looks "close enough".
+
+### 5.3 — Report discrepancies
+
+List every discrepancy found. Be specific (e.g., "heading font-size is 24px but
+reference shows 32px", "button background is blue-500 but should be blue-700",
+"missing 48px top padding on section").
+
+If no discrepancies are found → skip to
+[Step 7: Validate and Upload](#step-7-validate-and-upload).
+
+---
+
+## Step 6: Fix and Re-Check
+
+1. Open the component source at `src/components/<component_name>/index.jsx`
+2. Apply fixes for each discrepancy found in Step 5
+3. Save the file (Storybook hot-reloads automatically)
+4. Wait 2 seconds for hot reload to complete
+5. Re-screenshot:
+   ```bash
+   playwright-cli reload
+   playwright-cli screenshot --filename=storybook-<component-name>.png
+   ```
+6. Return to **Step 5** and compare again
+
+**Iteration limit:** If after 5 iterations the component still has significant
+discrepancies, stop and report the remaining gaps to the user rather than
+continuing to loop. Minor pixel-level differences (≤2px) are acceptable.
+
+---
+
+## Step 7: Validate and Upload
+
+Once visual parity is achieved for all components:
+
+### 7.1 — Validate
+
+Run the `nebula-component-validation` skill to fix formatting, linting, and
+Canvas requirements:
+
+```bash
+npm run code:fix
+```
+
+Resolve any remaining errors before proceeding.
+
+### 7.2 — Upload
+
+Run the `canvas-component-upload` skill to push to the Canvas site.
+
+---
+
+## Multi-Component Pages
+
+When QA-ing a page story (e.g., `homepage.stories.jsx`):
+
+1. Screenshot the full page story:
+   ```bash
+   playwright-cli open http://localhost:6006/iframe.html?id=<page-story-id>&viewMode=story
+   playwright-cli resize 1440 900
+   playwright-cli eval "document.documentElement.scrollHeight"
+   ```
+2. For each 900px section, scroll and screenshot
+3. Compare section-by-section against the reference
+4. Fix individual component files as needed
+5. Re-screenshot affected sections after each fix
+
+---
+
+## Example Run
+
+**Input:** Hero Banner component was built from a Figma URL.
+
+1. Get Figma screenshot for the Hero Banner node
+2. Open
+   `http://localhost:6006/iframe.html?id=components-hero-banner--default&viewMode=story`
+3. Screenshot at 1440px
+4. Compare: "heading is 24px but Figma shows 40px; background image is not full
+   bleed"
+5. Fix `src/components/hero_banner/index.jsx`
+6. Re-screenshot → compare again
+7. Match achieved → run `npm run code:fix` → upload

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,11 @@ const config = {
   addons: ["@storybook/addon-docs"],
   framework: {
     name: "@storybook/react-vite",
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: "vite.config.js",
+      },
+    },
   },
 };
 

--- a/canvas.config.json
+++ b/canvas.config.json
@@ -1,0 +1,3 @@
+{
+  "componentDir": "./src/components"
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import storybook from "eslint-plugin-storybook";
 import globals from "globals";
 
 export default [
-  { ignores: ["dist", "node_modules", "storybook-static"] },
+  { ignores: ["dist", "node_modules", "storybook-static", ".playwright-cli"] },
   ...drupalCanvasRecommended,
   ...storybook.configs["flat/recommended"],
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@drupal-canvas/eslint-config": "^0.1.0",
         "@drupal-canvas/vite-plugin": "^0.1.0",
         "@eslint/js": "^9.39.1",
+        "@freelygive/canvas-jsonapi": "^0.2.1",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@storybook/addon-docs": "^10.0.8",
         "@storybook/react-vite": "^10.0.8",
@@ -1051,6 +1052,32 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@freelygive/canvas-jsonapi": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@freelygive/canvas-jsonapi/-/canvas-jsonapi-0.2.1.tgz",
+      "integrity": "sha512-xBdXXmv0IGW+w/gZYLsGXm6GPpI4fgeyROsJVd0KoK582JiFF9Ew0uWZ3EqAY2bocb0F3aZNpxw9zO2ynVHp4g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "dotenv": "^16.0.0",
+        "drupal-jsonapi-params": "^3.0.0",
+        "js-yaml": "^4.1.1"
+      },
+      "bin": {
+        "canvas-jsonapi": "src/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@freelygive/npm-scaffold": ">=0.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@freelygive/npm-scaffold": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@drupal-canvas/eslint-config": "^0.1.0",
     "@drupal-canvas/vite-plugin": "^0.1.0",
     "@eslint/js": "^9.39.1",
+    "@freelygive/canvas-jsonapi": "^0.2.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@storybook/addon-docs": "^10.0.8",
     "@storybook/react-vite": "^10.0.8",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,20 @@
+import path from "path";
+import { fileURLToPath } from "url";
 import drupalCanvas from "@drupal-canvas/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
 
+// Manually define __dirname for ES Modules.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export default defineConfig({
   plugins: [react(), tailwindcss(), drupalCanvas()],
+  resolve: {
+    alias: {
+      // Use path.resolve to create an absolute path to your src folder.
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 });


### PR DESCRIPTION
## Add orchestration pipeline skills and update existing component skills

### Summary

This PR adds 7 new skills and updates 4 existing skills to support a complete end-to-end Canvas site-building workflow - from a source URL to live assembled pages - covering component building, visual QA, content migration, and page assembly.

---

### New skills

**Orchestration pipelines**

| Skill | What it does |
|---|---|
| `full-site-build` | End-to-end pipeline: builds components, migrates content, wires SWR data fetching, assembles Canvas pages. The top-level conductor that calls all other skills in order. |
| `build-and-deploy` | Component-only pipeline: build → visual QA → validate → upload. No content migration. |
| `build-from-url` | Entry point that auto-detects Figma vs. live URL and routes accordingly. Sits one level below `build-and-deploy`. |
| `site-content-migration` | Content-only pipeline: crawls source via Playwright (or Figma MCP), classifies content types, creates Drupal entities, and assembles Canvas pages. |

**Utilities**

| Skill | What it does |
|---|---|
| `visual-qa-loop` | Autonomous screenshot diff loop — Playwright screenshots of the live source vs. Storybook story, fixes and retries up to 5 iterations per component. |
| `content-management` | JSON:API page and content operations via `npx canvas-jsonapi` — list, get, create, update, delete pages, nodes, and media. Covers Canvas page structure, component `inputs`, `parent_uuid`/`slot` nesting, image `target_id` references, and rich text formatting. |
| `playwright-cli` | Browser automation used by QA and content migration phases for snapshots, screenshots, and nav extraction. |

---

### Updated skills

| Skill | What changed |
|---|---|
| `nebula-component-creation` | Added a static vs. dynamic classification gate before building. Dynamic components (repeating content collections) must use SWR + JSON:API — no list props, no hardcoded list data. |
| `nebula-component-validation` | Made post-validation visual QA mandatory. `code:fix` can rewrite JSX in ways that shift visual output — upload is blocked until a second QA pass confirms the component still matches the reference. |
| `canvas-component-upload` | Added mandatory global CSS upload step (`npx canvas upload --css-only`). Without it, components render unstyled on Canvas even if the component code uploaded successfully. |
| `canvas-component-metadata` | Added an array/object prop decision gate. Canvas does not support `type: array` in `component.yml` — these must become slots + child components. JSON string serialization (`JSON.parse` workarounds) is explicitly banned. |

---

### Key mechanisms introduced

**JSON:API page assembly (`content-management` + `site-content-migration`)**

Canvas pages are assembled by writing a flat `components` array to the `page` entity via `npx canvas-jsonapi`. Each component entry carries `component_id`, `inputs` (the prop values), and optional `parent_uuid` + `slot` for nesting child components inside slots. Images reference media entities by `target_id`; rich text fields use `{ "value": "<p>...</p>", "format": "canvas_html_block" }`.

**Source MCP for automatic entity creation (`site-content-migration` + `full-site-build`)**

When the source MCP is connected, missing Drupal content types and fields are created automatically via `create_content_type` + `add_field_to_content_type`. Taxonomy terms are created via `get_or_create_term`. When source MCP is absent, the pipeline pauses and outputs a checklist for the user to create types manually, then resumes on confirmation. Canvas `page` entities are never used as a substitute for a missing structured content type.

**SWR data wiring for dynamic components (`full-site-build` Phase B6.5)**

After content nodes are created, dynamic components are updated to fetch live data via `JsonApiClient` + `useSWR` from the appropriate `node--<type>` endpoint. CT field names are mapped to component prop names (strip `field_` prefix, camelCase the rest). Filter options (taxonomy terms, categories) are fetched dynamically — never hardcoded. Updated components are re-validated, re-QA'd, and re-uploaded.

---

### Supported flows (15 total)

| Flow | Steps | Trigger |
|---|---|---|
| 1 | build → QA → validate → QA → upload | "build and upload" |
| 2 | build → QA → validate → QA → **review** → upload | "let me review", "pause for Storybook" |
| 3 | build → QA → validate → QA → stop | "don't upload", "I'll upload manually" |
| 4 | build → QA → validate → QA → upload → page assembly | "build and deploy" |
| 5 | build → QA → validate → QA → **review** → upload → page | "build and deploy … pause for review" |
| 6–7 | Same as 1–2 with Figma source | Figma URL |
| 8 | Content migration only | "migrate content from" |
| 9 | Page assembly only | "assemble the page" |
| 10 | Full site (automated) | "full site from" |
| 11 | Full site + review gate | "full site from … pause for review" |
| 12–15 | QA / validate / upload utilities | "QA the components", "validate and upload", etc. |

The human review gate (flows 2, 5, 7, 11) is triggered purely by "pause", "let me review", or "sign-off" in the prompt — no skill changes required.

See `prompts.txt` for the full trigger phrase list per flow.

---

### Pipeline architecture

```
Source URL → build-from-url / full-site-build
               │
               ├─ Track A (Visual)
               │     scrape reference screenshots
               │     classify static vs. dynamic
               │     scaffold components (nebula-component-creation)
               │     implement design tokens (implement-design if Figma)
               │     create Storybook stories
               │     visual-qa-loop (mandatory, up to 5 iterations)
               │     validate (npm run code:fix)
               │     visual-qa-loop again (mandatory post-validation)
               │     upload components + global CSS
               │
               └─ Track B (Content, B1–B2 concurrent with A; B3+ after upload)
                     discover Canvas schema (npx canvas-jsonapi list --types)
                     crawl source (playwright-cli)
                     Content Type Gate:
                       source-mcp connected → auto-create types + fields
                       source-mcp absent    → pause, output checklist
                     create taxonomy terms
                     create menu items
                     create content nodes
                     wire SWR for dynamic components → re-upload
                                       ↓
               Merge: content-management → assemble Canvas pages
                      playwright-cli → verify live pages
```

---

### Test plan

- [ ] Flow 1: `"build and upload the hero component from [URL]"` — verify component uploads and global CSS is re-uploaded
- [ ] Flow 3: `"build components but don't upload yet"` — verify pipeline stops after post-validation QA
- [ ] Flow 8: `"migrate content from [URL]"` — verify content types, taxonomy terms, and nodes are created in Drupal
- [ ] Flow 8 with source MCP connected — verify missing content types are auto-created via `create_content_type` + `add_field_to_content_type`
- [ ] Flow 8 without source MCP — verify pipeline pauses and outputs the correct CT checklist
- [ ] Flow 10: `"full site from [URL]"` — verify end-to-end run produces assembled Canvas pages with real content wired in
- [ ] Dynamic component: verify SWR wiring in B6.5 fetches from the correct `node--<type>` endpoint
- [ ] Add an array prop to `component.yml` — verify `canvas-component-metadata` blocks it and requires slot decomposition
- [ ] Modify a component post-`code:fix` — verify `nebula-component-validation` triggers a second visual QA pass before allowing upload
