### PR TITLE
Add orchestration pipelines and update existing skills.

### DIFF
--- a/.agents/skills/build-and-deploy/SKILL.md
+++ b/.agents/skills/build-and-deploy/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: build-and-deploy
+description:
+  Full autonomous pipeline — takes any URL (Figma or web), builds Canvas
+  components, visually QAs them against the design reference, and uploads to
+  Canvas without any manual prompts in between. Use when the user wants a fully
+  hands-off run from URL to deployed components. Triggers on phrases like "do
+  everything", "full pipeline", "build and deploy", "hands-off", "run the full
+  loop", or "ralph loop".
+metadata:
+  mcp-server: figma, figma-desktop # optional — pipeline works without it
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Build and Deploy — Full Autonomous Pipeline
+
+Runs the complete workflow from URL to a live Canvas page without stopping for
+human input. Only stops if a hard error occurs that cannot be recovered
+automatically.
+
+## Pipeline Overview
+
+```
+URL provided
+    │
+    ▼
+Phase 1 — Build from URL              (build-from-url skill logic)
+    │
+    ▼
+Phase 2 — Visual QA Loop              (visual-qa-loop skill logic)  ← MANDATORY, multi-iteration
+    │
+    ▼
+Phase 3 — Validate & Re-QA & Upload
+    ├── 3a  Validate (nebula-component-validation / npm run code:fix)
+    ├── 3b  Visual QA again            ← MANDATORY after validation, auto-fix can shift output
+    └── 3c  Push (canvas-component-push)
+    │
+    ▼
+Phase 4 — Build Canvas Page           (content-management skill)    ← MANDATORY, do not skip
+    │
+    ▼
+Done — report summary
+```
+
+---
+
+## Rules for Autonomous Operation
+
+- **Do not ask clarifying questions** mid-run. Make reasonable decisions and
+  document them in the final report.
+- **Do not stop on warnings** — only stop on errors that block progress (missing
+  credentials, MCP connection failure, Workbench won't start).
+- **On recoverable errors** (upload conflict, lint error, hot reload delay) —
+  retry up to 3 times before reporting as a blocker.
+- **Max QA iterations per component:** 5. If a component still has gaps after 5
+  iterations, mark it as "needs manual review" and continue with the rest.
+- **At the end**, always output a structured summary (see
+  [Final Report](#final-report)).
+
+### HARD RULES — never skip these
+
+> ⛔ **Phase 2 is NOT optional.** A single screenshot glance is NOT QA. You MUST
+> complete the full visual-qa-loop for every component before proceeding to
+> Phase 3. "Looks close enough" is not acceptable — follow the full loop
+> including style manifest extraction and numeric diffing.
+
+> ⛔ **Phase 4 is NOT optional.** Uploading components is not "deployed".
+> Deployed means a Canvas page exists with those components arranged to match
+> the source URL. You MUST complete Phase 4. If page assembly is genuinely
+> blocked (e.g. missing site credentials), document why in the final report — do
+> NOT silently skip it.
+
+---
+
+## Phase 1: Build from URL
+
+Follow the full `build-from-url` skill:
+
+1. **Detect URL type**
+   - `figma.com/design/` or `figma.com/board/` → Figma URL, skip capture
+   - Any other URL → Web URL, run Playwright capture to Figma first
+
+2. **If Web URL — Playwright capture first (always)**
+   - Open at 1440×900 via playwright-cli (headed, Chrome)
+   - Dismiss popups/overlays
+   - Measure page height, detect sticky header
+   - Extract style manifest (computed font/color/spacing tokens from live DOM)
+   - Screenshot each section → save as reference images
+
+3. **If Figma MCP is connected — also capture to Figma**
+   - Create new Figma file via `generate_figma_design(outputMode: "newFile")`
+   - Capture each 900px section into Figma, poll until complete
+   - Save `fileKey` for design context extraction
+
+   **If Figma MCP is not connected** — skip this step, use Playwright
+   screenshots and style manifest as the build reference instead.
+
+4. **Fetch design context (Figma MCP only)**
+   - `get_design_context(fileKey, nodeId)` for each section/component
+   - If too large, use `get_metadata` then fetch child nodes individually
+
+5. **Get visual reference** — Figma screenshot if available, otherwise the
+   Playwright reference images from step 2
+
+6. **Build components**
+   - Follow `nebula-component-creation` patterns
+   - Apply `canvas-styling-conventions` for tokens and CVA variants
+   - Apply `canvas-component-definition` contract
+   - Apply `canvas-component-metadata` for `component.yml`
+   - Apply `canvas-component-utils` for FormattedText/Image
+
+7. **Ensure Workbench preview coverage** — author `mocks.json` for named states
+   as needed; follow the `canvas-workbench` skill
+
+---
+
+## Phase 2: Visual QA Loop
+
+> ⛔ This phase is **MANDATORY**. Do not proceed to Phase 3 until every
+> component has passed all steps below. One pass is not enough.
+
+For each component built in Phase 1, execute the **full** visual-qa-loop skill:
+
+1. **Ensure Workbench is running** — follow the `canvas-workbench` skill; in
+   this project run `npm run dev` in the background and note the local URL from
+   startup output
+
+2. **Get reference screenshot** — screenshot the live site section at 1440px
+   that corresponds to this component (scroll to the correct Y offset, dismiss
+   any overlays first)
+
+3. **Extract style manifest from live site** — run the computed-style eval from
+   the visual-qa-loop skill (Step 3B-extra) and save the output
+
+4. **Screenshot the Workbench component preview**
+   - URL: `<workbench-url>/?component=<component-name>&state=Default`
+   - Resize to 1440×900 before screenshotting
+
+5. **Extract style manifest from Workbench preview** — run the same
+   computed-style eval against the Workbench preview
+
+6. **Compare both** — screenshot side-by-side AND numeric style manifest diff:
+   - Layout: alignment, spacing, padding, margins
+   - Typography: font-family, size, weight, line-height, color
+   - Colors: backgrounds, text, borders
+   - Components: icons, images, buttons
+
+7. **If ANY discrepancy found** (visual OR numeric, beyond ≤2px tolerance):
+   - Fix `src/components/<name>/index.jsx`
+   - Wait 2 seconds for hot reload
+   - Re-screenshot and re-extract styles
+   - Return to step 6
+   - Repeat up to 5 times total
+   - After 5 iterations → mark as "needs manual review", document remaining gaps
+
+8. **A component is only "Matched" when ALL of the following are true:**
+   - Screenshot comparison shows no visible structural differences
+   - Style manifest diff shows no numeric mismatches beyond ≤2px/2% tolerance
+   - At least one full iteration (screenshot + style diff) was completed
+
+9. **If no discrepancies** → proceed to next component, then Phase 3
+
+---
+
+## Phase 3: Validate and Upload
+
+1. **Validate all components**
+
+   ```bash
+   npm run code:fix
+   ```
+
+   Fix any lint or formatting errors. Retry up to 3 times.
+
+2. **Re-run visual QA after validation** — ESLint/Prettier auto-fix can rewrite
+   JSX in ways that shift visual output. After `code:fix` passes, run the full
+   `visual-qa-loop` again for every component. Only proceed to upload once every
+   component still passes the visual QA check.
+
+   > ⛔ **This QA pass is mandatory.** A clean lint run does not mean the
+   > component still matches the reference. Do not upload until this second QA
+   > pass confirms it.
+
+3. **Push components to Canvas** — follow `canvas-component-push` skill.
+   `canvas push --yes` pushes all components and global CSS in one step; handle
+   dependency ordering, retry on conflict errors.
+
+---
+
+## Phase 4: Build Canvas Page
+
+> ⛔ This phase is **MANDATORY**. Do not report "done" until the page exists on
+> Canvas with the components placed and configured.
+
+1. **Check for an existing page** — list canvas pages via source MCP and check
+   if a page for this URL already exists. If it does, use `get_page_layout` to
+   read the current layout, then update it. If not, create a new one.
+
+   ```
+   list_entities(entity_type: "canvas_page")
+   ```
+
+2. **Create or update the page:**
+
+   New page:
+
+   ```
+   create_canvas_page(title: "<Page Title>", path: "/<path>")
+   → returns page_id
+   ```
+
+   Existing page — update metadata if needed:
+
+   ```
+   update_canvas_page(page_id: <id>, title: "...", path: "...")
+   ```
+
+3. **Read available components:**
+
+   ```
+   ReadMcpResourceTool(server: "source-mcp", uri: "canvas://components")
+   ```
+
+4. **Assemble the page** — for each section of the source URL, add the
+   corresponding uploaded component and configure its props to match the source
+   content (headings, images, text, links):
+
+   ```
+   add_component_to_page(page_id: <id>, component_id: "js.<name>", props: {
+     "<prop>": "<value from source>"
+   })
+   → returns new_instance_id
+   ```
+
+   For slotted children:
+
+   ```
+   add_component_to_page(
+     page_id: <id>,
+     component_id: "js.<child>",
+     parent_instance_id: "<parent-id>",
+     slot: "<slot-name>",
+     props: { ... }
+   )
+   ```
+
+5. **Publish the page:**
+
+   ```
+   ReadMcpResourceTool(server: "source-mcp", uri: "canvas://auto-saves")
+   → get autosave_key and data_hash
+
+   publish_auto_saves(autosaves: [{ autosave_key: "canvas_page:<id>:en", data_hash: "..." }])
+   ```
+
+6. **Verify the live Canvas page** — open the published Canvas page URL in
+   playwright-cli and take a screenshot. Compare it against the source URL
+   screenshot from Phase 1. Note any structural differences in the final report.
+
+7. **If page assembly is blocked** (e.g. source MCP not connected, API errors
+   that cannot be recovered after 3 retries) — document the specific blocker in
+   the final report. Do NOT silently skip this phase.
+
+---
+
+## Final Report
+
+At the end of the run, output a summary in this format:
+
+```
+## Build and Deploy — Summary
+
+**Source:** <URL provided>
+**Canvas page:** <URL of the assembled Canvas page, or "blocked — see notes">
+
+### Components
+| Component    | Built | QA Iterations | QA Status        | Uploaded |
+|--------------|-------|---------------|------------------|----------|
+| hero         | ✅    | 3             | ✅ Matched        | ✅       |
+| school_card  | ✅    | 1             | ✅ Matched        | ✅       |
+| cta_banner   | ✅    | 2             | ⚠️ Needs review   | ✅       |
+
+### Page Assembly
+| Step                        | Status |
+|-----------------------------|--------|
+| Canvas page created/updated | ✅ / ❌ |
+| Components placed           | ✅ / ❌ |
+| Live page verified          | ✅ / ❌ |
+
+### Notes
+- <any decisions made autonomously>
+- <any components flagged for manual review and why>
+- <any errors encountered and how they were resolved>
+- <reason if Phase 4 was blocked>
+
+### ⚠️ Manual Steps Required in Drupal
+
+This pipeline builds and deploys components only — it does not migrate content.
+The following Drupal-side tasks are outside the pipeline scope and must be done
+manually for the site to be fully functional.
+
+| Task | Drupal path | Notes |
+|------|-------------|-------|
+| **Vocabulary creation** (if needed) | `/admin/structure/taxonomy/add` | Required before content nodes with taxonomy references can be created |
+| **Menu creation** (if needed) | `/admin/structure/menu/add` | Required for header/footer/nav components to fetch live links |
+| **Menu links** | `/admin/structure/menu/manage/<name>` | Add links matching the source site nav structure |
+| **Content migration** | — | Run the `site-content-migration` skill to create nodes, terms, and pages |
+
+**Nav components (header, footer):** Render from a static fallback array until
+Drupal menus are created. Once the matching menu exists in Drupal, the component
+automatically fetches live links — no code change needed.
+```

--- a/.agents/skills/build-from-url/SKILL.md
+++ b/.agents/skills/build-from-url/SKILL.md
@@ -1,0 +1,491 @@
+---
+name: build-from-url
+description:
+  Build or implement a UI from any URL. Auto-detects the URL type — if it's a
+  Figma URL, builds directly using the Figma MCP; if it's any other web page
+  URL, captures Playwright screenshots and style tokens first (always), then
+  also converts to Figma if the MCP is connected for extra precision. Falls back
+  gracefully to Playwright-only if Figma MCP is not available — no manual setup
+  required. Use when the user shares any URL (Figma or web) with intent to
+  build, implement, recreate, or match a design. Triggers on phrases like "build
+  this", "implement this", "recreate this page", or any URL shared alongside a
+  build request.
+metadata:
+  mcp-server: figma, figma-desktop # optional — pipeline works without it
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Build from URL
+
+## URL Detection
+
+Check the URL the user shared:
+
+- Contains `figma.com/design/` or `figma.com/board/` → **Figma URL**, skip to
+  [Phase 2a: Build from Figma](#phase-2a-build-from-figma)
+- Any other URL → **Web URL**, start at
+  [Phase 1: Playwright Capture](#phase-1-playwright-capture-web-urls--always-run)
+
+---
+
+## Phase 1: Playwright Capture (Web URLs — always run)
+
+This phase is **always required** for web URLs. It produces the reference
+screenshots and style manifest used throughout the build and in Phase 3 QA.
+Figma MCP is not needed for this phase.
+
+### 1.1 — Open the page
+
+```bash
+playwright-cli open <URL> --browser=chrome
+playwright-cli resize 1440 900
+```
+
+Wait for the page to fully load.
+
+### 1.2 — Dismiss popups and overlays
+
+Try clicking common dismiss buttons:
+
+```bash
+playwright-cli click [aria-label*="Accept"]
+playwright-cli click [id*="cookie"] button
+playwright-cli click [class*="consent"] button
+```
+
+If a button was clicked, wait 500ms. Then suppress remaining overlays and
+restore scroll:
+
+```bash
+playwright-cli eval "document.querySelectorAll('[id*=\"cookie\"],[class*=\"cookie\"],[class*=\"consent\"],[class*=\"popup\"],[class*=\"banner\"],[class*=\"overlay\"]').forEach(el => el.style.display = 'none'); document.body.style.overflow = 'auto'"
+```
+
+### 1.3 — Measure the page
+
+```bash
+playwright-cli eval "document.documentElement.scrollHeight"
+playwright-cli eval "document.title"
+```
+
+Calculate sections: `ceil(height / 900)`
+
+### 1.3b — Extract design tokens from the live site
+
+Extract the site's actual computed styles so the build uses exact values rather
+than approximations. Save all three outputs as the **style manifest** — used in
+Phase 2 and `global.css`.
+
+**Typography and color tokens:**
+
+```bash
+playwright-cli eval "
+const targets = {
+  heading1: 'h1',
+  heading2: 'h2',
+  heading3: 'h3',
+  body: 'p',
+  nav: 'nav a, header a',
+  button: 'button, a[class*=\"btn\"], a[class*=\"button\"]',
+  header: 'header',
+  footer: 'footer',
+};
+const tokens = {};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  tokens[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    textTransform: s.textTransform,
+    padding: s.padding,
+    borderRadius: s.borderRadius,
+  };
+}
+JSON.stringify(tokens, null, 2)
+"
+```
+
+**Color palette:**
+
+```bash
+playwright-cli eval "
+const colors = new Map();
+document.querySelectorAll('*').forEach(el => {
+  const s = getComputedStyle(el);
+  const tag = el.tagName.toLowerCase();
+  if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)')
+    colors.set(s.backgroundColor, (colors.get(s.backgroundColor) || 0) + 1);
+  if (s.color)
+    colors.set(s.color, (colors.get(s.color) || 0) + 1);
+});
+JSON.stringify([...colors.entries()].sort((a,b) => b[1]-a[1]).slice(0,20).map(([c,n]) => ({color:c,count:n})))
+"
+```
+
+**Web fonts loaded:**
+
+```bash
+playwright-cli eval "
+[...document.fonts].map(f => ({ family: f.family, style: f.style, weight: f.weight, status: f.status }))
+  .filter(f => f.status === 'loaded')
+  .map(f => f.family + ' ' + f.weight)
+  .filter((v,i,a) => a.indexOf(v) === i)
+"
+```
+
+### 1.3c — Extract CSS custom properties (design tokens)
+
+Many sites expose their design system tokens as CSS custom properties on
+`:root`. These map directly to `@theme` variables in `global.css` — extract them
+before building so components use the site's actual token values rather than
+arbitrary hex codes.
+
+```bash
+playwright-cli eval "
+const cssVars = {};
+[...document.styleSheets].forEach(sheet => {
+  try {
+    [...sheet.cssRules].forEach(rule => {
+      if (rule.selectorText === ':root' || rule.selectorText === ':root, :host') {
+        [...rule.style].filter(p => p.startsWith('--')).forEach(p => {
+          cssVars[p] = rule.style.getPropertyValue(p).trim();
+        });
+      }
+    });
+  } catch(e) {}
+});
+JSON.stringify(cssVars, null, 2)
+"
+```
+
+Save the output as the **CSS token map**. At build time, map these directly to
+`@theme` entries in `global.css` (e.g. `--color-brand: #1899cb` →
+`--color-primary-600: #1899cb`). If the site has no custom properties, skip this
+step and rely on the colour palette from Phase 1.3b.
+
+---
+
+### 1.4 — Detect sticky header
+
+```bash
+playwright-cli eval "window.scrollTo(0, 200)"
+playwright-cli eval "window.scrollTo(0, 0)"
+playwright-cli eval "window.__stickyEls = Array.from(document.querySelectorAll('*')).filter(el => { const s = getComputedStyle(el); return (s.position === 'fixed' || s.position === 'sticky') && el.getBoundingClientRect().top < 200; }); window.__stickyEls.reduce((h, el) => h + el.getBoundingClientRect().height, 0)"
+```
+
+Save the result as `stickyHeight` (0 if none).
+
+### 1.5 — Screenshot each section (reference images)
+
+For each section at `scrollY = 0, 900, 1800, ...`:
+
+1. Scroll to position and wait 1 second for content to settle
+2. For sections after the first (`scrollY > 0`), hide sticky elements
+3. Take a screenshot and save to `.playwright-cli/<section-name>-reference.png`
+4. Note the pixel boundaries (top/bottom Y) of each distinct visual section
+5. Restore sticky elements after each screenshot
+
+These reference images are the source of truth for Phase 3 QA.
+
+---
+
+## Figma MCP Check
+
+> After completing Phase 1, check whether Figma MCP tools are available.
+
+- **Figma MCP connected** → proceed to
+  [Phase 1.6: Capture to Figma](#phase-16-capture-to-figma-optional--figma-mcp-connected)
+  for enhanced design context, then build via **Phase 2a**
+- **Figma MCP not connected** → skip Phase 1.6, proceed directly to
+  **[Phase 2b: Build from Playwright Reference](#phase-2b-build-from-playwright-reference-figma-mcp-not-connected)**
+
+**Quality note:** A user-provided native Figma URL produces significantly better
+components — `get_design_context` returns semantic component structure, design
+tokens, and auto-layout that maps directly to code. An auto-captured file (Phase
+1.6) is a DOM snapshot with flat, class-named layers; use it for visual
+reference only. In both cases, the Phase 1 Playwright style manifest is the
+authoritative source for exact token values — never override it with values from
+a captured file.
+
+---
+
+## Phase 1.6: Capture to Figma (optional — Figma MCP connected)
+
+### 1.6a — Create a new Figma file
+
+```
+generate_figma_design(outputMode: "newFile", fileName: "<page title>")
+```
+
+Save the `fileKey` from the response.
+
+### 1.6b — Identify semantic sections
+
+Before capturing, use Playwright to identify named sections on the page. These
+become the component names for the build and the Figma frame names — making
+`get_metadata` and `get_design_context` output meaningful instead of anonymous
+scroll chunks.
+
+```bash
+playwright-cli eval "
+const seen = new Set();
+const results = [];
+const candidates = document.querySelectorAll(
+  'header, footer, nav, main > section, main > div[class], [class*=hero], [class*=banner], [class*=cta], [class*=feature], [class*=card]'
+);
+candidates.forEach(function(el) {
+  const rect = el.getBoundingClientRect();
+  if (rect.height < 50) return;
+  const tag = el.tagName.toLowerCase();
+  const cls = (el.className || '').toString().trim().split(/\s+/).find(function(c) { return c.length > 2; }) || tag;
+  const key = cls + '-' + Math.round(rect.top + window.scrollY);
+  if (!seen.has(key)) { seen.add(key); results.push({ label: cls, top: Math.round(rect.top + window.scrollY) }); }
+});
+JSON.stringify(results)
+"
+```
+
+Save the output as your **section map** — a list of `{ label, top }` entries.
+Each `label` becomes the component name (e.g. `hero`, `nav`, `card-grid`,
+`footer`). Fall back to scroll-based sections (0, 900, 1800…) only if the eval
+returns fewer than 2 results.
+
+### 1.6c — Capture each named section
+
+For each entry in the section map:
+
+1. Scroll to position:
+   ```bash
+   playwright-cli eval "window.scrollTo(0, <top>)"
+   ```
+2. Wait 1 second for content to settle.
+3. For sections after the first, hide sticky elements:
+   ```bash
+   playwright-cli eval "window.__stickyEls.forEach(el => el.style.visibility = 'hidden')"
+   ```
+4. Inject Figma's capture script:
+   ```bash
+   playwright-cli eval "fetch('https://mcp.figma.com/mcp/html-to-design/capture.js').then(r=>r.text()).then(t=>{const s=document.createElement('script');s.textContent=t;document.head.appendChild(s)})"
+   ```
+5. Get a new captureId:
+   ```
+   generate_figma_design(outputMode: "existingFile", fileKey: "<fileKey>")
+   ```
+6. Trigger capture:
+   ```bash
+   playwright-cli eval "window.figma.captureForDesign({ captureId: '<captureId>', endpoint: '<endpoint>', selector: 'body' })"
+   ```
+7. Poll `generate_figma_design(captureId: "<captureId>")` every 5 seconds until
+   status is `completed`.
+8. Restore sticky elements:
+   ```bash
+   playwright-cli eval "window.__stickyEls.forEach(el => el.style.visibility = '')"
+   ```
+
+### 1.6d — Close browser and verify capture
+
+```bash
+playwright-cli close
+```
+
+Construct the Figma file URL from the `fileKey` saved in step 1.6a:
+
+```
+https://figma.com/design/<fileKey>
+```
+
+Share this URL with the user as a clickable link so they can open the file and
+inspect the captured frames before the build proceeds.
+
+Then pause and ask:
+
+> "The page has been captured into Figma:
+> [View captured file](https://figma.com/design/<fileKey>)
+>
+> Please open the link and check that the frames look usable (sections are
+> visible, text is readable, layout is roughly correct).
+>
+> - **Looks good** → reply "proceed" and I'll build components from this Figma
+>   file (Phase 2a)
+> - **Capture is poor** → reply "skip figma" and I'll build directly from the
+>   Playwright reference screenshots instead (Phase 2b)"
+
+Wait for the user's reply before continuing.
+
+- User replies "proceed" (or similar) → continue to **Phase 2a**
+- User replies "skip figma" (or similar) → skip Phase 2a, go to **Phase 2b**
+
+---
+
+## Phase 2a: Build from Figma
+
+_Use this path when Figma MCP is connected (either a direct Figma URL, or after
+Phase 1.6 capture)._
+
+### 2a.0 — Determine Figma source type
+
+Establish which type of Figma source you are working with — this changes how you
+use every subsequent step:
+
+**Native Figma URL** (user provided a `figma.com/design/...` link):
+
+- `get_design_context` is authoritative — trust its component structure, prop
+  names, layout, and code output
+- Run `get_variable_defs` to extract named design tokens (colors, spacing, type)
+- Style manifest from Phase 1 supplements where Figma tokens are absent
+
+**Auto-captured file** (created in Phase 1.6 via `generate_figma_design`):
+
+- The file is a DOM snapshot — layers are flat and named after CSS classes, not
+  semantic components
+- Use `get_screenshot` per frame for visual reference only
+- Use `get_metadata` to map frame labels (set in Phase 1.6b) back to component
+  names
+- Do **not** treat `get_design_context` code output as component structure or
+  use its CSS values as token names — the style manifest from Phase 1 is the
+  only reliable token source
+
+### 2a.1 — Parse fileKey and nodeId
+
+For Figma URLs: `https://figma.com/design/:fileKey/:fileName?node-id=1-2`
+
+- **fileKey**: segment after `/design/`
+- **nodeId**: `node-id` query param value (convert `-` to `:`)
+
+For pages captured in Phase 1.6: use the `fileKey` from the capture response.
+
+### 2a.2 — Fetch design context and tokens
+
+```
+get_design_context(fileKey=":fileKey", nodeId="1:2")
+```
+
+If the response is too large, use `get_metadata` first to get the node map, then
+fetch specific child nodes individually.
+
+**For native Figma URLs only** — also run:
+
+```
+get_variable_defs(fileKey=":fileKey", nodeId="1:2")
+```
+
+This extracts named design tokens (colors, spacing, typography). Map these to
+`@theme` CSS variables in `global.css` before writing component code.
+
+### 2a.3 — Get visual reference
+
+```
+get_screenshot(fileKey=":fileKey", nodeId="1:2")
+```
+
+Keep this screenshot as the source of truth throughout implementation.
+
+### 2a.4 — Download assets
+
+Use any `localhost` URLs returned by the Figma MCP server directly. Do not
+import new icon packages or create placeholders.
+
+### 2a.5 — Build components
+
+- Follow `nebula-component-creation` patterns
+- **Style manifest (Phase 1.3b) is always the authoritative token source** —
+  exact font sizes, weights, colors, spacing. For native Figma,
+  `get_variable_defs` supplements with named design tokens. For auto-captured
+  files, the style manifest is the only reliable source — do not use CSS values
+  from `get_design_context` as token values or component props
+- Add site-specific colors to `src/components/global.css` as `@theme` CSS
+  variables before writing component code
+- Load any web fonts from the manifest via `@import url(...)` in `global.css`
+- Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+- Apply `canvas-component-definition` contract
+- Apply `canvas-component-metadata` for `component.yml`
+- Apply `canvas-component-utils` for FormattedText/Image
+- Ensure Workbench preview coverage following the `canvas-workbench` skill;
+  author `mocks.json` if named states are needed beyond the built-in Default
+  preview
+
+### 2a.6 — Validate checklist
+
+- [ ] Layout matches (spacing, alignment, sizing)
+- [ ] Typography matches (font, size, weight, line height)
+- [ ] Colors match exactly
+- [ ] Interactive states work (hover, active, disabled)
+- [ ] Assets render correctly
+- [ ] Accessibility standards met
+
+---
+
+## Phase 2b: Build from Playwright Reference (Figma MCP not connected)
+
+_Use this path when Figma MCP is not available. The reference screenshots from
+Phase 1.5 and style manifest from Phase 1.3b replace Figma as the source of
+truth._
+
+### 2b.1 — Identify components from reference screenshots
+
+Review the section screenshots saved in Phase 1.5. Identify each distinct visual
+component (navbar, hero, cards, footer, etc.) and note its pixel boundaries.
+
+### 2b.2 — Build components
+
+- Follow `nebula-component-creation` patterns
+- **Use the style manifest from Phase 1.3b as the source of truth** for all
+  token values:
+  - Add site-specific colors to `src/components/global.css` as `@theme` CSS
+    variables
+  - Use exact `font-size`, `font-weight`, `line-height`, `letter-spacing` values
+    from the manifest
+  - Match `padding` and `border-radius` to the extracted values
+  - Load web fonts found in the manifest via `@import url(...)` in `global.css`
+- Use the Playwright reference screenshots as the visual guide for layout and
+  proportions
+- Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+- Apply `canvas-component-definition` contract
+- Apply `canvas-component-metadata` for `component.yml`
+- Apply `canvas-component-utils` for FormattedText/Image
+- Ensure Workbench preview coverage following the `canvas-workbench` skill;
+  author `mocks.json` if named states are needed beyond the built-in Default
+  preview
+
+### 2b.3 — Validate checklist
+
+- [ ] Layout matches reference screenshot (spacing, alignment, sizing)
+- [ ] Typography matches style manifest values exactly
+- [ ] Colors match style manifest palette
+- [ ] Interactive states work (hover, active, disabled)
+- [ ] Accessibility standards met
+
+---
+
+## Phase 3: Visual QA Loop (MANDATORY)
+
+**This phase is NOT optional.** After building components and creating stories,
+you MUST run the visual QA loop before considering the build complete. The
+reference screenshots from Phase 1.5 are the QA baseline — Figma MCP is not
+required.
+
+### 3.1 — Run the visual-qa-loop skill
+
+Invoke the `visual-qa-loop` skill with the original URL and the Phase 1.5
+reference screenshots as the design reference. This will:
+
+1. Screenshot each component preview in Canvas Workbench
+2. Compare against the reference screenshots (and Figma if available)
+3. Fix discrepancies (typography, spacing, colors, layout)
+4. Re-screenshot and iterate until visual parity is achieved
+5. Run final validation (`npm run code:fix`)
+
+### 3.2 — Completion criteria
+
+The build is **only complete** when:
+
+- [ ] All components pass visual QA (no discrepancies > 2px)
+- [ ] `npm run code:fix` exits with 0 errors
+
+**Do NOT report the build as finished until Phase 3 is done.**

--- a/.agents/skills/canvas-component-metadata/SKILL.md
+++ b/.agents/skills/canvas-component-metadata/SKILL.md
@@ -238,6 +238,56 @@ examples:
   - 1
 ```
 
+## Array and object data — MANDATORY decision gate
+
+Canvas **does not support** `type: array` or inline `properties` objects in
+`component.yml`. Whenever you encounter or author a prop that holds a list or
+object value, you **must** decompose it into slots and child components.
+**Silently removing the array prop with no replacement is never acceptable** —
+it leaves components rendering empty/broken content.
+
+### Only strategy — Slots
+
+Every list or structured object prop must become a slot. Decompose the parent
+component to accept child components via a named slot, and create a child
+component for each item type. See the **Slots** section and the
+`canvas-component-composability` skill for full decomposition rules.
+
+```yaml
+# parent component.yml
+slots:
+  links:
+    title: Links
+```
+
+```jsx
+// parent index.jsx
+const Hero = ({ heading, links }) => (
+  <section>
+    <h1>{heading}</h1>
+    <ul>{links}</ul>
+  </section>
+);
+```
+
+Child components (e.g., `link_item`) are placed inside the slot via
+`parent_uuid` + `slot` on the Canvas page.
+
+> ⛔ **Do NOT use JSON string serialization** (`propNameJson: type: string` +
+> `JSON.parse`). It is not a supported pattern — it bypasses the Canvas editor
+> and makes content uneditable by authors.
+
+### Checklist when touching any array/object prop
+
+- [ ] Decomposed array prop into a named slot in `component.yml`
+- [ ] Created or reused a child component for each item type
+- [ ] Parent JSX consumes the named slot prop directly (no `JSON.parse`)
+- [ ] Canvas page updated — child components reference the correct `parent_uuid`
+      and `slot` name
+- [ ] **Never left an array prop removed with no replacement**
+
+---
+
 ## Enums
 
 Enum values must use lowercase, machine-friendly identifiers. Use `meta:enum` to

--- a/.agents/skills/canvas-data-fetching/SKILL.md
+++ b/.agents/skills/canvas-data-fetching/SKILL.md
@@ -111,6 +111,78 @@ params.addFields('taxonomy_term--categories', ['name']);
 params.addFields('file--file', ['uri', 'url']);
 ```
 
+## Navigation / Menu Components
+
+Components like headers, footers, and sidebars often need menu links from
+Drupal. Use a **dual implementation**: fetch from a Drupal menu when one exists,
+and fall back to a static array when no menu is configured yet.
+
+This means the component works immediately (using the hardcoded fallback), and
+automatically upgrades to live Drupal-managed links once the CMS editor creates
+the corresponding menu.
+
+```jsx
+import { JsonApiClient, sortMenu } from 'drupal-canvas';
+import useSWR from 'swr';
+
+// Static fallback — always define this; it renders when no Drupal menu exists
+const FALLBACK_LINKS = [
+  { id: 'home', title: 'Home', url: '/' },
+  { id: 'about', title: 'About', url: '/about' },
+];
+
+const client = new JsonApiClient();
+
+const Navigation = ({ menuName = 'main' }) => {
+  const { data, error, isLoading } = useSWR(
+    menuName ? ['menu_items', menuName] : null,
+    ([type, id]) => client.getResource(type, id),
+  );
+
+  // Use live Drupal menu links when available; otherwise use fallback
+  const links =
+    !error && !isLoading && data ? Array.from(sortMenu(data)) : FALLBACK_LINKS;
+
+  return (
+    <nav>
+      {links.map(({ id, title, url }) => (
+        <a key={id} href={url}>
+          {title}
+        </a>
+      ))}
+    </nav>
+  );
+};
+```
+
+**Rules for menu components:**
+
+- Always define a `FALLBACK_LINKS` constant with representative links. This
+  makes the component useful in Workbench and on sites where the Drupal menu
+  hasn't been created yet.
+- Expose `menuName` as a prop and register it in `component.yml` so CMS editors
+  can configure which Drupal menu to use without code changes.
+- `menuName = null` disables fetching (SWR key is `null`) and renders the
+  fallback — useful for pure static previews.
+- After building a nav-type component, include a note in the manual steps
+  summary telling the user to create the corresponding menu in Drupal at
+  `/admin/structure/menu/add`.
+
+**`component.yml` example for `menuName`:**
+
+```yaml
+props:
+  properties:
+    menuName:
+      title: Menu name
+      type: string
+      examples:
+        - main
+        - footer
+```
+
+---
+
 ## Creating content list components
 
 When building a component that displays a list of content items (e.g., a news

--- a/.agents/skills/content-management/SKILL.md
+++ b/.agents/skills/content-management/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: content-management
+description:
+  Managing content in Acquia Source via source MCP tools including canvas pages,
+  nodes, media, and taxonomy terms. No CLI or JSON:API credentials needed.
+---
+
+# Content Management Skill
+
+Manages content in Acquia Source using **source MCP tools** directly. Requires
+the source MCP server to be connected.
+
+---
+
+## Discover Available Content Types
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "drupal://content-types")
+```
+
+Or list existing entities of a type:
+
+```
+list_entities(entity_type: "node", bundle: "article")
+list_entities(entity_type: "taxonomy_term", bundle: "tags")
+list_entities(entity_type: "canvas_page")
+```
+
+---
+
+## Content Nodes
+
+### Create
+
+```
+create_node(bundle: "article", fields: {
+  "title": "My Article",
+  "body": { "value": "<p>HTML body</p>", "format": "basic_html" },
+  "field_tags": [{ "target_id": 1 }],
+  "status": true,
+  "path": { "alias": "/my-article" }
+})
+```
+
+Use `batch_create_nodes` to create multiple nodes of the same bundle at once.
+
+### Update (partial)
+
+```
+update_node(entity_id: 42, fields: {
+  "title": "Updated Title",
+  "body": { "value": "<p>Updated body</p>", "format": "basic_html" }
+})
+```
+
+---
+
+## Taxonomy Terms
+
+```
+get_or_create_term(vid: "tags", name: "Technology")
+```
+
+Returns the term ID whether it already existed or was just created.
+
+---
+
+## Media (Images)
+
+### Upload
+
+```
+create_media(
+  bundle: "image",
+  name: "My Image",
+  filename: "photo.jpg",
+  metadata: { "alt": "Alt text description" }
+)
+```
+
+After calling `create_media`, upload the file using the returned signed URL:
+
+```bash
+curl -X PUT <upload_url> -H "Content-Type: application/octet-stream" --data-binary @/path/to/photo.jpg
+```
+
+The returned `target_id` is the **media entity's internal ID** — use this in
+component props that reference images.
+
+### Media vs File Entity IDs (Critical)
+
+| Entity Type | ID Location                            | Usage                      |
+| ----------- | -------------------------------------- | -------------------------- |
+| **File**    | `drupal_internal__target_id` in rels   | Internal file reference    |
+| **Media**   | `target_id` returned by `create_media` | **Use this in components** |
+
+Always use the **media entity's internal ID**, not the file's.
+
+### Remote video
+
+```
+create_remote_video(bundle: "remote_video", url: "https://www.youtube.com/watch?v=...")
+```
+
+---
+
+## Canvas Pages
+
+Canvas pages are layout containers that compose uploaded components. Use for:
+homepage, section landing pages (e.g. /academics, /news), utility pages.
+
+**Never use canvas pages as a substitute for missing structured content types.**
+
+### Available components
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://components")
+```
+
+Returns each component's `id`, `props`, and `slots`.
+
+### Full creation workflow
+
+**1. Create the page:**
+
+```
+create_canvas_page(title: "My Page", path: "/my-page")
+→ returns page_id
+```
+
+**2. Add root-level components:**
+
+```
+add_component_to_page(page_id: 5, component_id: "js.hero", props: {
+  "heading": "Welcome",
+  "subheading": "Subtitle text"
+})
+→ returns new_instance_id
+```
+
+**3. Add slotted child components:**
+
+```
+add_component_to_page(
+  page_id: 5,
+  component_id: "js.hero_button",
+  parent_instance_id: "<hero-instance-id>",
+  slot: "ctaButtons",
+  props: { "label": "Learn More", "url": "/about" }
+)
+```
+
+**4. Publish the draft:**
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://auto-saves")
+→ get autosave_key and data_hash
+
+publish_auto_saves(autosaves: [{ autosave_key: "canvas_page:5:en", data_hash: "..." }])
+```
+
+### Other page operations
+
+| Goal                      | Tool                                                         |
+| ------------------------- | ------------------------------------------------------------ |
+| Update component props    | `update_component_props(page_id, instance_id, props)`        |
+| Reorder a component       | `move_component(page_id, instance_id, region, index)`        |
+| Remove a component        | `remove_component(page_id, instance_id)`                     |
+| Read current layout       | `get_page_layout(page_id)`                                   |
+| Update page title/path    | `update_canvas_page(page_id, title, path)`                   |
+| Delete a page             | `delete_canvas_page(page_id, force: true)`                   |
+| Discard unpublished draft | `discard_auto_saves(autosave_keys: ["canvas_page:<id>:en"])` |
+
+### Canvas component nesting
+
+Components are nested via `parent_instance_id` and `slot`. Root-level components
+have no parent. Slotted children reference the parent's `new_instance_id` and
+the slot name from `canvas://components`.
+
+---
+
+## Canvas Component Structure
+
+When composing pages, the layout is a tree of component instances:
+
+```
+Hero (js.hero) — root
+  └── ctaButtons slot
+        └── Hero Button (js.hero_button)
+Campus Life (js.campus_life) — root
+  └── activities slot
+        └── Campus Activity (js.campus_activity)
+        └── Campus Activity (js.campus_activity)
+```
+
+Add in top-down order: create the parent first, get its `instance_id`, then
+create children referencing it.
+
+---
+
+## Text Fields with HTML
+
+Rich text fields use a specific format:
+
+```json
+{
+  "body": {
+    "value": "<p>HTML content with <a href=\"/page\">links</a>.</p>",
+    "format": "basic_html"
+  }
+}
+```
+
+Canvas HTML block format (for component props):
+
+```json
+{
+  "value": "<p>Content</p>",
+  "format": "canvas_html_block"
+}
+```
+
+### Allowed HTML elements
+
+**Inline:** `<strong>` `<em>` `<u>` `<s>` `<sup>` `<sub>` `<a>` `<code>`
+
+**Block:** `<p>` `<h2>`–`<h6>` `<ul>` `<ol>` `<li>` `<blockquote>`
+
+**Alignment classes:** `.text-align-center` `.text-align-right`
+`.text-align-justify`
+
+**Embedded media:**
+
+```html
+<drupal-media data-entity-type="media" data-entity-uuid="MEDIA-UUID"
+  >&nbsp;</drupal-media
+>
+```
+
+Use the media entity UUID (from `create_media` response), not the file UUID. The
+`&nbsp;` placeholder inside the tag is required.
+
+### Content formatting best practices
+
+1. Use `<strong>` for important text, `<em>` for emphasis — semantic, not just
+   visual styling.
+2. `<blockquote>` for external quotes only. For regular inline quotes, use
+   quotation marks inside a `<p>` tag.
+3. Use `<ul>`/`<ol>` for lists rather than comma-separated text.
+4. Use `<h2>`–`<h6>` to create clear content structure.
+
+---
+
+## Workflow: Create a Page with Images
+
+1. **Upload image:**
+
+   ```
+   create_media(bundle: "image", name: "Card Image", filename: "card.jpg",
+     metadata: { "alt": "Description" })
+   → target_id: 31
+   ```
+
+   Then upload the file using the returned signed URL.
+
+2. **Create the canvas page:**
+
+   ```
+   create_canvas_page(title: "My Page", path: "/my-page")
+   → page_id: 5
+   ```
+
+3. **Add component with image reference:**
+
+   ```
+   add_component_to_page(page_id: 5, component_id: "js.impact_card", props: {
+     "cardTitle": "My Card",
+     "description": "Card text",
+     "image": { "target_id": 31 }
+   })
+   ```
+
+4. **Publish:**
+
+   ```
+   ReadMcpResourceTool(uri: "canvas://auto-saves") → data_hash
+   publish_auto_saves(autosaves: [{ autosave_key: "canvas_page:5:en", data_hash: "..." }])
+   ```
+
+---
+
+## Source MCP Capabilities and Limitations
+
+Always be explicit with the user about what can and cannot be automated.
+
+### ✅ Handled automatically by source MCP
+
+| Operation                                        | Tool                                        |
+| ------------------------------------------------ | ------------------------------------------- |
+| Create content type                              | `create_content_type`                       |
+| Add fields to content type                       | `add_field_to_content_type`                 |
+| Create taxonomy terms (in existing vocabularies) | `get_or_create_term`                        |
+| Create content nodes                             | `create_node` / `batch_create_nodes`        |
+| Upload media (images, video)                     | `create_media` / `create_remote_video`      |
+| Create and publish Canvas pages                  | `create_canvas_page` / `publish_auto_saves` |
+
+### ⚠️ Requires manual action in Drupal
+
+After any content management task, always surface the following as a checklist
+for the user — only include items that are relevant to the current task:
+
+| Task                                | Drupal path                                     | When needed                                                                  |
+| ----------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| **Create vocabulary**               | `/admin/structure/taxonomy/add`                 | Any time content uses tags/categories in a vocabulary that doesn't exist yet |
+| **Create menu**                     | `/admin/structure/menu/add`                     | When a header, footer, or nav component needs a Drupal menu to fetch from    |
+| **Add menu links**                  | `/admin/structure/menu/manage/<menu-name>`      | After creating a menu; list label + path + parent for each link              |
+| **Expose content type in JSON:API** | `/admin/config/services/jsonapi/resource_types` | If a new content type was created and is not yet accessible via JSON:API     |
+
+**Nav components (header, footer):** These include a static fallback array and
+work immediately. Once the corresponding Drupal menu exists with the correct
+machine name, they automatically switch to live Drupal-managed links — no code
+change needed.

--- a/.agents/skills/full-site-build/SKILL.md
+++ b/.agents/skills/full-site-build/SKILL.md
@@ -1,0 +1,557 @@
+---
+name: full-site-build
+description:
+  End-to-end autonomous pipeline — takes any source URL (or Figma URL), builds
+  all Canvas components AND migrates all structured content in parallel, then
+  assembles the final Canvas pages with real components wired to real content.
+  When source MCP is connected, missing content types and fields are created
+  automatically. If source MCP is absent and types are missing, the pipeline
+  pauses for the user. Triggers on phrases like "full site from URL", "build and
+  migrate", "end to end from URL", "full site build", "build the full site",
+  "build site and migrate content", "do everything end to end".
+metadata:
+  mcp-server: figma, figma-desktop
+allowed-tools: Bash(playwright-cli:*), Bash(npm *)
+---
+
+# Full Site Build — End-to-End Pipeline
+
+Builds Canvas components AND migrates structured content from one source URL,
+then assembles Canvas pages that wire the two together. Runs both tracks in
+parallel; only stops at the Content Type Gate if Drupal content types are
+missing.
+
+## Pipeline Overview
+
+```
+Source URL (and/or Figma URL)
+    │
+    ├─── Track A: Component Build ──────────────────────────────────────────┐
+    │      Phase A1 — Capture source into Figma (if web URL)                │
+    │               └── A1 verify: confirm Figma file has visible content   │
+    │      Phase A2 — Build React components                                │
+    │      Phase A3 — Visual QA loop (mandatory, multi-iteration)           │
+    │      Phase A4 — Validate → Re-QA → Upload                            │
+    │               ├── A4a  Validate (npm run code:fix)                   │
+    │               ├── A4b  Visual QA again ← MANDATORY after validate    │
+    │               └── A4c  Upload to Canvas                              │
+    │      Phase A5 — Upload images to Drupal media, wire to Canvas instances│
+    │                                                                        │
+    ├─── Track B: Content Migration ────────────────────────────────────────┤
+    │      Phase B1 — Discover Canvas site schema (source MCP)              │
+    │      Phase B2 — Crawl source (Playwright)                             │
+    │      Phase B3 — Content Type Gate                                      │
+    │               ↳ source-mcp connected → auto-create types & fields     │
+    │               ↳ source-mcp absent   → STOP, wait for user             │
+    │      Phase B4 — Create taxonomy terms (source MCP)                    │
+    │      Phase B5 — Create menu items (manual — not supported by MCP)     │
+    │      Phase B6 — Create content nodes (source MCP)                     │
+    │                                                                        │
+    └─── Merge: Canvas Page Assembly ───────────────────────────────────────┘
+           Phase C — Build Canvas pages: real components + real content
+                     (image props already wired by A5 — publish only after)
+           Phase D — Verify live Canvas pages
+    │
+    ▼
+Done — final report
+```
+
+Tracks A and B run **concurrently** — start both before waiting on either. Phase
+C (page assembly) only runs after **both** A4+A5 and B6 are complete.
+
+---
+
+## Rules for Autonomous Operation
+
+- **Do not ask clarifying questions** mid-run. Make reasonable decisions and
+  document them in the final report.
+- **Content Type Gate (Phase B3):** If source MCP is connected, auto-create
+  missing content types and fields — no stop needed, proceed straight to B4. If
+  source MCP is NOT connected, output the CT checklist and **STOP** until the
+  user confirms. All other errors: retry up to 3 times, then document and
+  continue.
+- **Max QA iterations per component:** 5. If still failing after 5, mark as
+  "needs manual review" and continue.
+- **Never substitute Canvas `page` for a missing structured content type.**
+- **Phase A1 Figma verification is mandatory.** After `generate_figma_design`
+  completes, screenshot the result and confirm visible content exists. An empty
+  or all-white frame is a failure — do not proceed to A2 without content.
+- **Phase A5 is mandatory.** Every image prop in every Canvas page component
+  instance must be wired to a Drupal media `target_id` before pages are
+  published. Do not report "done" with `null` image props.
+- **Phase C is mandatory.** Do not report "done" until Canvas pages exist with
+  components placed and content wired in.
+
+---
+
+## Track A: Component Build
+
+### Phase A1 — Capture to Figma (web URLs only)
+
+Skip this phase if the source is already a `figma.com` URL.
+
+1. Open source URL at 1440×900 via `playwright-cli open --browser=chrome`
+2. Dismiss cookie banners, popups, overlays
+3. Detect page height and sticky header offset
+4. **Capture into Figma (external URL — CSP-bypass required):**
+
+   > ⚠ Do NOT call `generate_figma_design` and assume it captured content.
+   > For external URLs the tool only generates a `captureId` — you must inject
+   > the capture script via Playwright to actually capture the page.
+
+   a. Call `generate_figma_design(outputMode: "newFile")` → save `captureId`
+   b. Run the CSP-bypass Playwright injection (required for all external URLs):
+
+      ```
+      playwright-cli run-code "async page => {
+        await page.route('**/*', async (route) => {
+          const response = await route.fetch();
+          const headers = { ...response.headers() };
+          delete headers['content-security-policy'];
+          delete headers['content-security-policy-report-only'];
+          await route.fulfill({ response, headers });
+        });
+        await page.goto('<SOURCE_URL>');
+        const r = await page.context().request.get('https://mcp.figma.com/mcp/html-to-design/capture.js');
+        await page.evaluate((s) => { const el = document.createElement('script'); el.textContent = s; document.head.appendChild(el); }, await r.text());
+        await page.waitForTimeout(500);
+        return await page.evaluate(() => window.figma.captureForDesign({
+          captureId: '<captureId>',
+          endpoint: 'https://mcp.figma.com/mcp/capture/<captureId>/submit',
+          selector: 'body'
+        }));
+      }"
+      ```
+
+   c. Poll `generate_figma_design(captureId: "<captureId>")` every 5 s until
+      status is `completed`
+   d. Save `fileKey` **and** the `node-id` from the returned URL
+      (e.g., `?node-id=2-2` → nodeId `2:2`) — this is the captured frame
+
+5. **Verify content exists** — immediately after capture:
+   - Use the `node-id` from step 4d (NOT `0:1` — the root canvas is always
+     blank and will give a false negative)
+   - Call `get_screenshot(fileKey: "<fileKey>", nodeId: "<captured-node-id>")`
+   - Inspect the screenshot — if all-white, blank, or contains only a frame
+     outline with no visible page content, the capture failed silently
+   - **Failure recovery:** Re-open the source URL, scroll slowly through the
+     full page height, take section screenshots with Playwright, then call
+     `generate_figma_design` again with `outputMode: "existingFile"` targeting
+     the same `fileKey` to re-capture, or create a new file
+   - Only proceed to A2 once the screenshot confirms visible content in Figma
+
+> ⛔ An empty Figma file is a hard blocker for A2. Do not build components
+> against a blank design — the visual reference will be missing.
+
+### Phase A2 — Build Components
+
+For each visual section of the source:
+
+1. `get_design_context(fileKey, nodeId)` per section
+2. Build React component following `nebula-component-creation` patterns
+3. Apply `canvas-styling-conventions` (Tailwind tokens, CVA variants)
+4. Apply `canvas-component-definition` contract
+5. Apply `canvas-component-metadata` for `component.yml`
+6. Apply `canvas-component-utils` for FormattedText/Image
+7. Ensure Workbench preview coverage (author `mocks.json` for named states as
+   needed; follow `canvas-workbench` skill)
+
+### Phase A3 — Visual QA Loop (MANDATORY)
+
+> ⛔ Do not skip. One screenshot glance is not QA.
+
+For each component:
+
+1. Start Workbench if not running: `npm run dev`; note the URL from startup
+   output (follow `canvas-workbench` skill)
+2. Screenshot live site section at 1440px (correct Y offset, no overlays)
+3. Extract computed style manifest from live site
+4. Screenshot Workbench component preview at
+   `<workbench-url>/?component=<component-name>&state=Default` (resize 1440×900)
+5. Extract computed style manifest from Workbench preview
+6. Compare: layout, typography, colors, spacing — tolerance ≤2px/2%
+7. If any diff → fix `src/components/<name>/index.jsx` → wait 2s → re-compare
+8. Repeat up to 5 iterations. After 5 → mark "needs manual review", move on
+9. Component is "Matched" only when: screenshot AND style manifest both pass
+
+### Phase A4 — Validate & Upload
+
+1. **Validate**
+
+   ```bash
+   npm run code:fix
+   ```
+
+   Fix lint/formatting errors. Retry up to 3 times until passing.
+
+2. **Re-run visual QA after validation** — ESLint/Prettier auto-fix can rewrite
+   JSX in ways that shift visual output. After `code:fix` passes, run the full
+   `visual-qa-loop` again for every component. Only proceed to upload once every
+   component still passes the visual QA check.
+
+   > ⛔ **This QA pass is mandatory.** A clean lint run does not mean the
+   > component still matches the reference. Do not upload until this second QA
+   > pass confirms it.
+
+3. **Push** — follow `canvas-component-push` skill. `canvas push --yes` pushes
+   all components and global CSS in one step; handle dependency ordering, retry
+   on conflict.
+
+### Phase A5 — Upload Images to Drupal Media and Wire to Canvas
+
+Run after A4c (components pushed). This phase must complete before any Canvas
+page is published in Phase C.
+
+1. **Collect image URLs** — from the source site crawl (B2), build a list of
+   every image that appears in a Canvas page component instance (hero
+   backgrounds, card images, spotlight images, etc.).
+
+2. **Create Drupal media entities** — for each image, upload via source MCP:
+
+   ```
+   create_media(bundle: "image", name: "<descriptive-name>", filename: "<file.jpg>",
+     metadata: { "alt": "<alt text>" })
+   ```
+
+   Upload the file using the returned signed URL. Record each `target_id`.
+
+3. **Wire image props to Canvas component instances** — for each Canvas page,
+   get the current layout (`get_page_layout`), match component instances to
+   their images, then call `update_component_props` with:
+   ```
+   { "<image-prop>": { "target_id": <drupal-media-id> } }
+   ```
+
+4. **Verify** — confirm every image prop in every component instance resolves
+   to a non-null image URL in the `resolved` output. If any remain `null`,
+   debug and retry before proceeding.
+
+> ⛔ Do NOT publish Canvas pages (Phase C step 5) until all image props are
+> wired. A page with `"image": null` is incomplete.
+
+---
+
+## Track B: Content Migration
+
+### Phase B1 — Discover Canvas Site Schema
+
+Read available content types via source MCP:
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "drupal://content-types")
+list_entities(entity_type: "taxonomy_vocabulary")
+```
+
+Record every available type. Types that matter:
+
+- `node--*` — writable content node types
+- `taxonomy_term--*` — taxonomy vocabularies
+- `canvas_page` — Canvas layout pages (always present)
+
+### Phase B2 — Crawl Source (Playwright)
+
+Use Playwright as the default. Do not try WebFetch first — most modern sites
+need JavaScript.
+
+```bash
+playwright-cli open <source-url>
+playwright-cli snapshot
+```
+
+Visit 5–10 representative pages. From each snapshot YAML, extract:
+
+- URL patterns and page titles
+- Nav structure (section names, hierarchy)
+- Content signals: dates, authors, bios, tags, images, download links
+- Repeating patterns (cards, profiles, listings, etc.)
+
+If a Figma URL was also provided: use `get_design_context` to extract the
+content schema (field names, required vs optional, relationships). Figma defines
+the schema; Playwright provides the actual values.
+
+Classify each content pattern into a canonical type derived from what the source
+actually contains (do not hardcode a fixed type list).
+
+### Phase B3 — Content Type Gate
+
+Check classified types against those discovered in Phase B1.
+
+- Type exists → continue to B4
+- Type **missing** → probe source MCP (Step 1 below)
+
+> ⛔ Never create Canvas `page` entities as a substitute for a missing
+> structured content type.
+
+#### Step 1 — Probe source MCP
+
+Call `ListMcpResourcesTool` with `server: "source-mcp"`:
+
+- **Succeeds** → source MCP is connected → **auto-create missing types
+  (Step 2)**
+- **Fails / not connected** → fall back to manual checklist (Step 3)
+
+#### Step 2 — Auto-create via source MCP (source-mcp connected)
+
+For each missing content type:
+
+1. **Create the content type:** Use `create_content_type` with `machine_name`,
+   `label`, `workflow: "editorial"` (default unless another workflow is known),
+   and optional `description`.
+
+2. **Add each custom field:** Use `add_field_to_content_type` — map inferred
+   data to the correct `field_type`:
+
+   | Data from source                | MCP `field_type`                          |
+   | ------------------------------- | ----------------------------------------- |
+   | Short text (title, name, label) | `string`                                  |
+   | Long formatted text (body, bio) | `text_long`                               |
+   | Long text with summary          | `text_with_summary`                       |
+   | Date / time                     | `datetime`                                |
+   | URL / link                      | `link`                                    |
+   | Email address                   | `email`                                   |
+   | True/false toggle               | `boolean`                                 |
+   | Fixed list of text values       | `list_string`                             |
+   | Reference to another node       | `field_ui:entity_reference:node`          |
+   | Reference to taxonomy term      | `field_ui:entity_reference:taxonomy_term` |
+   | Image or file                   | `field_ui:entity_reference:media`         |
+
+3. **Verify exposure:** Re-read `drupal://content-types` to confirm the new type
+   appears. Retry up to 3 times. If still missing, warn the user to expose it at
+   `/admin/config/services/jsonapi/resource_types` and wait for confirmation.
+
+4. **Source MCP limitations** — handle gracefully, do not stop the pipeline:
+   - Cannot create new vocabularies — only vocabularies that already exist on
+     the site can be used
+   - Cannot create menus — see Phase B5 for menu handling
+
+Proceed to B4 once all types are confirmed.
+
+#### Step 3 — Manual checklist (source MCP not connected)
+
+Output the following block for each missing type and **STOP**:
+
+---
+
+**⚠ Action required — pipeline paused at content migration.**
+
+Source MCP is not connected. Connect it and retry, or create the following
+Drupal content types manually, then reply "done" to resume:
+
+1. `/admin/structure/types/add`
+2. Add the fields listed
+3. `/admin/config/services/jsonapi/resource_types` — expose the type
+
+##### Content Type: `<machine-name>`
+
+**Label:** `<Human Readable Name>` **Purpose:** `<what this content represents>`
+**Source URL example:** `<a real URL of this content type>`
+
+| Field label | Machine name | Drupal field type | Required       |
+| ----------- | ------------ | ----------------- | -------------- |
+| Title       | title        | Text (plain)      | Yes (built-in) |
+| ...         | field\_...   | ...               | ...            |
+
+**Expose in JSON:API as:** `node--<machine-name>`
+
+---
+
+Resume Phase B4 only after user confirms all types exist.
+
+### Phase B4 — Create Taxonomy Terms
+
+Discover available vocabularies:
+
+```
+list_entities(entity_type: "taxonomy_vocabulary")
+```
+
+Create terms:
+
+```
+get_or_create_term(vid: "<vocab-machine-name>", name: "<Term Name>")
+```
+
+`get_or_create_term` is idempotent — safe to call even if the term may already
+exist. Record every returned term ID — required for node relationship fields.
+
+If content requires a vocabulary that doesn't exist on the site, inform the user
+to create it manually at `/admin/structure/taxonomy/add` before resuming.
+
+### Phase B5 — Create Menu Items
+
+Menu links are not supported via source MCP. Inform the user to create menu
+items manually at `/admin/structure/menu/manage/main` and move on.
+
+Output a list of menu items for the user to create based on the nav structure
+extracted in Phase B2.
+
+### Phase B6 — Create Content Nodes
+
+Creation order (dependency-safe):
+
+1. Taxonomy terms (done in B4)
+2. Media/images — upload before nodes that reference them:
+
+   ```
+   create_media(bundle: "image", name: "<name>", filename: "<file.jpg>",
+     metadata: { "alt": "<alt text>" })
+   ```
+
+   Upload the file using the returned signed URL. Record each `target_id`.
+
+3. Independent nodes (e.g. `person`) — no references to other nodes:
+
+   ```
+   create_node(bundle: "<type>", fields: {
+     "title": "<Title>",
+     "status": true,
+     "body": { "value": "<p>HTML</p>", "format": "basic_html", "summary": "" },
+     "path": { "alias": "/<slug>" },
+     "field_<ref>": { "target_id": <id> }
+   })
+   ```
+
+4. Dependent nodes (e.g. `article` referencing `person`) — after step 3.
+
+Use `batch_create_nodes` when creating multiple nodes of the same bundle.
+
+HTML body: only `p strong em a ul ol li h2 h3 h4 blockquote`.
+
+---
+
+## Merge: Canvas Page Assembly
+
+Run Phase C only after **both** A4+A5 (components uploaded, images wired) and
+B6 (nodes created) are complete.
+
+### Phase C — Build Canvas Pages
+
+Canvas `canvas_page` entities are layout containers only — not content stores.
+Use them for: homepage, section landing pages (e.g. /academics, /news), utility
+pages (404).
+
+For each page, wire the uploaded components with real content from B6.
+
+**1. Create the page:**
+
+```
+create_canvas_page(title: "<Page Title>", path: "/<path>")
+→ returns page_id
+```
+
+**2. Read available components:**
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://components")
+```
+
+**3. Add each component with real prop values from crawled content:**
+
+```
+add_component_to_page(page_id: <id>, component_id: "js.<machine_name>", props: {
+  "<prop>": "<real value from B6 content>"
+})
+→ returns new_instance_id
+```
+
+**4. Add slotted children (if needed):**
+
+```
+add_component_to_page(
+  page_id: <id>,
+  component_id: "js.<child_component>",
+  parent_instance_id: "<parent-instance-id>",
+  slot: "<slot-name>",
+  props: { ... }
+)
+```
+
+**5. Publish each page:**
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://auto-saves")
+→ get autosave_key and data_hash for each page
+
+publish_auto_saves(autosaves: [{ autosave_key: "canvas_page:<id>:en", data_hash: "..." }])
+```
+
+### Phase D — Verify Live Pages
+
+Open each assembled Canvas page in playwright-cli. Screenshot and compare
+against the source URL screenshot from A1. Note structural differences in the
+final report.
+
+---
+
+## Final Report
+
+```
+## Full Site Build — Summary
+
+**Source:** <URL>
+**Canvas site:** <CANVAS_SITE_URL>
+
+### Track A: Components
+| Component | Built | QA Iterations | QA Status | Uploaded |
+|-----------|-------|--------------|-----------|---------|
+| hero      | ✅    | 2            | ✅ Matched | ✅      |
+| ...       |       |              |           |         |
+
+### Phase A1: Figma Capture
+| Step | Status |
+|------|--------|
+| Capture completed | ✅ / ❌ |
+| Figma content verified (non-empty screenshot) | ✅ / ❌ |
+| fileKey | `<fileKey>` |
+
+### Phase A5: Images
+| Image | Drupal media ID | Wired to instance | Status |
+|-------|-----------------|-------------------|--------|
+| hero-bg | ... | hero/backgroundImage | ✅ |
+| ... | | | |
+
+### Track B: Content
+| Step | Status | Count |
+|------|--------|-------|
+| Canvas schema discovered | ✅ | N types available |
+| Content types confirmed | ✅ / ⚠ pending | N missing |
+| Taxonomy terms created | ✅ | N terms |
+| Menu items | manual | N items listed for user |
+| Content nodes created | ✅ | N nodes |
+
+### Canvas Pages Assembled
+| Page | URL | Status |
+|------|-----|--------|
+| Homepage | / | ✅ live |
+| ...      |   |        |
+
+### Notes
+- <autonomous decisions made>
+- <components needing manual review>
+- <content types that were missing and required user action>
+- <any errors and how resolved>
+
+### ⚠️ Manual Steps Required in Drupal
+
+The following cannot be automated. Complete these before the site is fully
+functional.
+
+**What was handled automatically:**
+- ✅ Content types (auto-created via `create_content_type`)
+- ✅ Fields (auto-added via `add_field_to_content_type`)
+- ✅ Taxonomy terms in existing vocabularies
+- ✅ Content nodes, media, Canvas pages
+
+**Still needs manual action:**
+
+| Task | Drupal path | Details |
+|------|-------------|---------|
+| Vocabulary creation | `/admin/structure/taxonomy/add` | <list new vocab names, or "none"> |
+| Menu creation | `/admin/structure/menu/add` | <list menu names, or "none"> |
+| Menu links | `/admin/structure/menu/manage/<name>` | <paste the link table from Phase B5> |
+| JSON:API exposure | `/admin/config/services/jsonapi/resource_types` | <list any new node types> |
+
+**Nav components (header, footer):** These render from a static fallback until
+Drupal menus are created. Once menus exist with the correct machine name, the
+components automatically fetch live links — no code change needed.
+```

--- a/.agents/skills/playwright-cli/SKILL.md
+++ b/.agents/skills/playwright-cli/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: playwright-cli
+description:
+  Automates browser interactions for web testing, form filling, screenshots, and
+  data extraction. Use when the user needs to navigate websites, interact with
+  web pages, fill forms, take screenshots, test web applications, or extract
+  information from web pages.
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+playwright-cli fill e5 "user@example.com"
+playwright-cli drag e2 e8
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli snapshot --filename=after-click.yaml
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli network
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start
+playwright-cli video-stop video.webm
+```
+
+## Open parameters
+
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+# Connect to browser via extension
+playwright-cli open --extension
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser
+state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command.
+
+If `--filename` is not provided, a new snapshot file is created with a
+timestamp. Default to automatic file naming, use `--filename=` when artifact is
+a part of the workflow result.
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Local installation
+
+In some cases user might want to install playwright-cli locally. If running
+globally available `playwright-cli` binary fails, use `npx playwright-cli` to
+run the commands. For example:
+
+```bash
+npx playwright-cli open https://example.com
+npx playwright-cli click e1
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli network
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Specific tasks
+
+- **Request mocking**
+  [references/request-mocking.md](references/request-mocking.md)
+- **Running Playwright code**
+  [references/running-code.md](references/running-code.md)
+- **Browser session management**
+  [references/session-management.md](references/session-management.md)
+- **Storage state (cookies, localStorage)**
+  [references/storage-state.md](references/storage-state.md)
+- **Test generation**
+  [references/test-generation.md](references/test-generation.md)
+- **Tracing** [references/tracing.md](references/tracing.md)
+- **Video recording**
+  [references/video-recording.md](references/video-recording.md)

--- a/.agents/skills/playwright-cli/references/request-mocking.md
+++ b/.agents/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,88 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or
+delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.agents/skills/playwright-cli/references/running-code.md
+++ b/.agents/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,233 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not
+covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.loading', { state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.waitForSelector('.result', { timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('a.download-link')
+  ]);
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.click('.maybe-missing', { timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.fill('input[name=email]', 'user@example.com');
+  await page.fill('input[name=password]', 'secret');
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.agents/skills/playwright-cli/references/session-management.md
+++ b/.agents/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,171 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on
+`open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.agents/skills/playwright-cli/references/storage-state.md
+++ b/.agents/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,276 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive
+  operations

--- a/.agents/skills/playwright-cli/references/test-generation.md
+++ b/.agents/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,91 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding
+Playwright TypeScript code. This code appears in the output and can be copied
+directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { expect, test } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more
+resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your
+test:
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertion
+await expect(page.getByText('Success')).toBeVisible();
+```

--- a/.agents/skills/playwright-cli/references/tracing.md
+++ b/.agents/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,144 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM
+snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several
+files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category        | Details                                            |
+| --------------- | -------------------------------------------------- |
+| **Actions**     | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM**         | Full DOM snapshot before/after each action         |
+| **Screenshots** | Visual state at each step                          |
+| **Network**     | All requests, responses, headers, bodies, timing   |
+| **Console**     | All console.log, warn, error messages              |
+| **Timing**      | Precise timing for each operation                  |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature                 | Trace       | Video       | Screenshot       |
+| ----------------------- | ----------- | ----------- | ---------------- |
+| **Format**              | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection**      | Yes         | No          | No               |
+| **Network details**     | Yes         | No          | No               |
+| **Step-by-step replay** | Yes         | Continuous  | Single frame     |
+| **File size**           | Medium      | Large       | Small            |
+| **Best for**            | Debugging   | Demos       | Quick capture    |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.agents/skills/playwright-cli/references/video-recording.md
+++ b/.agents/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,44 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or
+verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Start recording
+playwright-cli video-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop demo.webm
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-stop recordings/login-flow-2024-01-15.webm
+playwright-cli video-stop recordings/checkout-test-run-42.webm
+```
+
+## Tracing vs Video
+
+| Feature  | Video                | Tracing                                  |
+| -------- | -------------------- | ---------------------------------------- |
+| Output   | WebM file            | Trace file (viewable in Trace Viewer)    |
+| Shows    | Visual recording     | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis                      |
+| Size     | Larger               | Smaller                                  |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.agents/skills/site-content-migration/SKILL.md
+++ b/.agents/skills/site-content-migration/SKILL.md
@@ -1,0 +1,583 @@
+---
+name: site-content-migration
+description:
+  Migrate structured content (menus, taxonomy, nodes) from any source into a
+  Canvas/Drupal site using source MCP tools — no module installation required.
+  The source can be a live website URL (crawled with Playwright) or a Figma
+  design file (analyzed with the Figma MCP). Claude classifies content, infers
+  the required Drupal content type schema, and creates all entities via source
+  MCP. Use when building a new Canvas site from an existing web source or
+  design. Triggered by phrases like "migrate content from URL", "migrate content
+  from Figma", "set up content structure from site", "import content types from
+  URL/design", or "migrate site content".
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Site Content Migration Skill
+
+Migrates structured content from any source into Canvas/Drupal using
+**Playwright + Figma MCP + source MCP tools**. Requires source MCP to be
+connected.
+
+The source can be:
+
+- **A live website URL** — crawled with Playwright to extract real content
+- **A Figma design file** — analyzed with the Figma MCP to extract the content
+  schema from the design's components and annotations
+- **Both** — Figma defines the schema; the live site provides the actual data
+
+---
+
+## Analysis Toolkit
+
+| Tool                              | Best for                                   | Limitation                                 |
+| --------------------------------- | ------------------------------------------ | ------------------------------------------ |
+| **Playwright** (`playwright-cli`) | Any live website — default choice          | Higher token cost (~5–30k tokens/page)     |
+| **WebFetch** (built-in)           | Known static CMS (Drupal/WordPress) only   | No JavaScript — fails on most modern sites |
+| **Figma MCP**                     | Schema extraction from design files        | No actual content values                   |
+| **Claude analysis**               | Classifying content, inferring field types | Only as good as the input                  |
+
+**Default: always use Playwright.** Most modern sites use JavaScript for
+rendering. WebFetch only saves tokens if it succeeds — if the site needs JS
+(increasingly common), using WebFetch first wastes tokens on a failed attempt
+before switching to Playwright anyway. Use WebFetch only as an optional
+quick-check when you have prior knowledge the site is fully server-rendered.
+
+---
+
+## Input Detection
+
+Before starting, identify what the user has provided:
+
+| Input                      | Detection         | Analysis method                                  |
+| -------------------------- | ----------------- | ------------------------------------------------ |
+| `figma.com/design/...` URL | Figma design link | Figma MCP (`get_design_context`, `get_metadata`) |
+| `figma.com/board/...` URL  | FigJam board      | Figma MCP (`get_figjam`)                         |
+| Any other URL              | Live website      | Playwright (`playwright-cli`) — default          |
+| Both Figma + live URL      | Design + content  | Figma for schema, Playwright for data            |
+
+If only a Figma URL is given with no live site, phases 2b–2d use design analysis
+only and produce a content schema + CT checklist. Actual node creation (Phase 6)
+is deferred until the user provides real content data.
+
+---
+
+## Pipeline Overview
+
+```
+Source (URL and/or Figma link)
+    │
+    ▼
+Phase 1 — Discover Canvas site schema
+  What content types, vocabularies, and menus already exist?
+    │
+    ▼
+Phase 2 — Analyze source
+  Live URL → Playwright crawl
+  Figma URL → Figma MCP analysis
+  Both → merge findings
+    │
+    ▼
+Phase 3 — Content Type Gate
+  Compare classified content against available types.
+  source-mcp connected → auto-create missing types & fields, continue
+  source-mcp absent + types missing → output checklist, STOP until user confirms
+  Do NOT create Canvas pages as a substitute for missing content types.
+    │
+    ▼
+Phase 4 — Create taxonomy terms
+  Map discovered categories/tags → create taxonomy_term entities via source MCP
+    │
+    ▼
+Phase 5 — Create menu items
+  Extract nav structure → inform user to create menu items manually
+    │
+    ▼
+Phase 6 — Create content nodes
+  Create nodes of the correct type for each piece of content via source MCP
+    │
+    ▼
+Phase 7 — Create Canvas pages
+  Build layout pages that compose uploaded components with real content
+    │
+    ▼
+Done — report summary
+```
+
+---
+
+## Phase 1: Discover Canvas Site Schema
+
+Read available content types via source MCP:
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "drupal://content-types")
+```
+
+Also discover vocabularies:
+
+```
+list_entities(entity_type: "taxonomy_vocabulary")
+```
+
+Record every available type. Types that matter:
+
+- `node--*` — writable content node types (e.g. `node--article`, `node--person`)
+- `taxonomy_term--*` — taxonomy vocabularies
+- `canvas_page` — Canvas layout pages (always present)
+
+---
+
+## Phase 2: Analyze Source
+
+### 2a — Live website (Playwright)
+
+Use Playwright for all live website crawls. Do not attempt WebFetch first — most
+modern sites use JavaScript and WebFetch would return skeleton HTML, wasting
+tokens before you switch to Playwright anyway.
+
+```bash
+playwright-cli open <source-url>
+playwright-cli snapshot
+# Read the snapshot YAML file to extract nav links
+# Do NOT use playwright-cli eval with arrow functions — it fails serialization
+```
+
+Visit 5–10 representative pages. After each snapshot, read the YAML and extract:
+
+- Page title and URL pattern
+- Nav links (reveals site structure and section names)
+- Presence of dates, author bylines, tags, bios, images, download links
+- Repeating structural patterns (cards, profiles, news items, etc.)
+
+**When WebFetch is acceptable (optional token saving):** Only if you have
+confirmed prior knowledge that the source site is a fully server-rendered CMS
+(classic Drupal/WordPress with no JS framework). In that case, use WebFetch to
+fetch a few representative URLs and read the returned markdown directly. If the
+response body is thin (< ~200 words of meaningful content), immediately open
+Playwright without asking the user — do not report the WebFetch failure.
+
+### 2b — Figma design file (Figma MCP)
+
+If the user provides a `figma.com` URL, use the Figma MCP to analyze it.
+
+**Step 1 — get the top-level structure:**
+
+```
+get_metadata(fileKey, nodeId)   ← use nodeId "0:1" for the root/page overview
+```
+
+Identify pages and frames that represent distinct content types (e.g. an
+"Article Detail" frame, a "Faculty Profile" frame, a "Programs" listing frame).
+
+**Step 2 — get design context for each content frame:**
+
+```
+get_design_context(fileKey, nodeId)   ← run for each content-type frame
+```
+
+From the returned code and screenshot, extract:
+
+- What data fields are rendered (title, date, author, bio, image, tags, etc.)
+- What is required vs optional (shown on all variants vs only some)
+- What relationships exist (e.g. article references a person as author)
+
+**Step 3 — check for Code Connect mappings:**
+
+```
+get_code_connect_map(fileKey, nodeId)
+```
+
+If components are already mapped to code, use the component names and props to
+confirm field names.
+
+**What Figma tells you vs what it doesn't:** | Figma can reveal | Figma cannot
+reveal | |---|---| | Content type schema (fields, types) | Actual content data |
+| Required vs optional fields | Real taxonomy terms | | Relationships between
+types | Actual node counts or IDs | | URL/path structure (from annotations) |
+Whether a live site exists |
+
+When only a Figma file is provided (no live URL), proceed through Phase 3 (CT
+checklist) and Phase 4 (taxonomy), but **skip Phase 6** (node creation) and note
+that the user must supply real content data before nodes can be created.
+
+### 2c — Both Figma + live URL
+
+Use Figma for schema definition (field names, types, relationships), and
+Playwright for harvesting the actual content data to populate nodes. Figma takes
+precedence for field naming if there is ambiguity.
+
+### 2d. Classify content into types
+
+For each distinct content pattern found, determine the canonical content type.
+Use the source as the guide — what repeating entity types exist?
+
+Common patterns (examples only — always derive from actual source):
+
+| Source signals                               | Canonical type | Key fields                                                             |
+| -------------------------------------------- | -------------- | ---------------------------------------------------------------------- |
+| Date + author/byline, news/blog section      | `article`      | title, body, date, author, category, image                             |
+| Name + bio + role/title, people/team section | `person`       | title, first_name, last_name, job_title, department, bio, photo, email |
+| Program/service/offering with description    | `service_area` | title, body, key_capabilities, image                                   |
+| Date + location + registration               | `event`        | title, body, date, end_date, location, registration_url, image         |
+| Downloadable file or guide                   | `resource`     | title, body, file, resource_type                                       |
+| General informational/landing page           | `page`         | title, body, image                                                     |
+| Question + answer pairs                      | `faq`          | title, question, answer, category                                      |
+
+These are **examples only**. Never hardcode this list as the output — always
+derive types from what the source actually contains.
+
+---
+
+## Phase 3: Content Type Gate
+
+After classifying content, check which required types already exist via
+`drupal://content-types` resource (Phase 1).
+
+For each classified content pattern:
+
+- If the matching `node--<type>` exists → proceed to Phase 4
+- If it is **not** in the list → probe source MCP (Step 1 below)
+
+**Rules:**
+
+1. **Never create Canvas `page` entities as a substitute for a missing
+   structured content type.** Canvas pages are for layout composition only.
+2. **Never hardcode a fixed set of content types.** Always derive what is needed
+   from the source site analysis.
+3. **Output one checklist entry per missing type**, with fields inferred from
+   the source content — not from a template.
+
+### Step 1 — Probe source MCP
+
+Call `ListMcpResourcesTool` with `server: "source-mcp"`:
+
+- **Succeeds** → source MCP is connected → **auto-create missing types
+  (Step 2)**
+- **Fails / not connected** → fall back to manual checklist (Step 3)
+
+### Step 2 — Auto-create via source MCP (source-mcp connected)
+
+For each missing content type:
+
+1. **Name the type** using a machine-name-safe slug (e.g. `article`, `person`,
+   `event`, `program`, `case_study`).
+
+2. **Create the content type:** Use `create_content_type` with `machine_name`,
+   `label`, `workflow: "editorial"` (default unless another workflow is known),
+   and optional `description`.
+
+3. **Add each custom field:** Use `add_field_to_content_type` — map inferred
+   data to the correct `field_type`:
+
+   | Data from source                | MCP `field_type`                          |
+   | ------------------------------- | ----------------------------------------- |
+   | Short text (title, name, label) | `string`                                  |
+   | Long formatted text (body, bio) | `text_long`                               |
+   | Long text with summary          | `text_with_summary`                       |
+   | Date / time                     | `datetime`                                |
+   | URL / link                      | `link`                                    |
+   | Email address                   | `email`                                   |
+   | True/false toggle               | `boolean`                                 |
+   | Fixed list of text values       | `list_string`                             |
+   | Reference to another node       | `field_ui:entity_reference:node`          |
+   | Reference to taxonomy term      | `field_ui:entity_reference:taxonomy_term` |
+   | Image or file                   | `field_ui:entity_reference:media`         |
+
+4. **Verify exposure:** Re-read `drupal://content-types` to confirm the new type
+   appears. Retry up to 3 times. If still missing, warn the user to expose it at
+   `/admin/config/services/jsonapi/resource_types` and wait for confirmation.
+
+5. **Source MCP limitations** — handle gracefully, do not stop the pipeline:
+   - Cannot create new vocabularies — only vocabularies that already exist on
+     the site can be used (discover them via `list_entities` with
+     `entity_type: "taxonomy_vocabulary"`)
+   - Cannot create menus — see Phase 5 for menu handling
+
+Proceed to Phase 4 once all types are confirmed.
+
+### Step 3 — Manual checklist (source MCP not connected)
+
+Output the following block for each missing type and **STOP**:
+
+---
+
+**⚠ Action required: content migration is paused.**
+
+Source MCP is not connected. Connect it and retry, or create the following
+Drupal content types manually, then reply "done" to resume:
+
+1. Go to `/admin/structure/types/add`
+2. Add the fields listed
+3. Go to `/admin/config/services/jsonapi/resource_types` and expose the type
+4. Reply "done" and migration will resume
+
+---
+
+### How to generate the Content Type Checklist (for Step 3)
+
+For each missing type, Claude must:
+
+1. **Name the type** using a machine-name-safe slug derived from the content
+   (e.g. `article`, `person`, `event`, `program`, `case_study`).
+2. **List the fields** by reading actual content from the source pages — what
+   data is displayed? Each visible piece of data is a field.
+3. **Choose the right Drupal field type** for each field:
+
+   | Data                                         | Drupal field type                                 |
+   | -------------------------------------------- | ------------------------------------------------- |
+   | Short text (title, name, label)              | Text (plain)                                      |
+   | Long formatted text (body, bio, description) | Text (formatted, long, with summary)              |
+   | Date/time                                    | Date                                              |
+   | URL / link                                   | Link                                              |
+   | Email address                                | Email                                             |
+   | True/false toggle                            | Boolean                                           |
+   | One value from a fixed list                  | List (text)                                       |
+   | Reference to another node                    | Entity reference → node                           |
+   | Reference to a taxonomy term                 | Entity reference → taxonomy_term                  |
+   | Image or file                                | Entity reference → media--image / media--document |
+
+4. **Mark required fields** — fields that every item of that type must have.
+
+#### Content Type Checklist output format
+
+#### Content Type: `<machine-name>`
+
+**Label:** `<Human Readable Name>` **Purpose:**
+`<one sentence — what this content represents on the source site>` **Source URL
+example:** `<url of a page that is this content type>`
+
+Fields to add:
+
+| Field label | Machine name | Drupal field type | Required       |
+| ----------- | ------------ | ----------------- | -------------- |
+| Title       | title        | Text (plain)      | Yes (built-in) |
+| ...         | field\_...   | ...               | ...            |
+
+**Expose in JSON:API as:** `node--<machine-name>`
+
+---
+
+Only list types that are genuinely needed based on what was found in the crawl.
+Do not output types that have no source content.
+
+---
+
+## Phase 4: Create Taxonomy Terms
+
+After all required content types are confirmed, create taxonomy terms.
+
+Discover taxonomies from source content: category filters, tag clouds, topic
+labels, department names, etc.
+
+First discover available vocabularies:
+
+```
+list_entities(entity_type: "taxonomy_vocabulary")
+```
+
+Then create terms:
+
+```
+get_or_create_term(vid: "<vocab-machine-name>", name: "<Term Name>")
+```
+
+`get_or_create_term` is idempotent — safe to call even if the term may already
+exist. Returns the term ID needed for node relationship fields.
+
+If content requires a vocabulary that doesn't exist on the site, inform the user
+to create it manually at `/admin/structure/taxonomy/add` before resuming.
+
+---
+
+## Phase 5: Create Menu Items
+
+Menu links are not supported via source MCP. Inform the user to create menu
+items manually at `/admin/structure/menu/manage/main` and move on.
+
+If the site's navigation structure was extracted in Phase 2, output a list of
+menu items for the user to create manually:
+
+| Label     | Path       | Parent |
+| --------- | ---------- | ------ |
+| About     | /about     | —      |
+| Academics | /academics | —      |
+| ...       | ...        | ...    |
+
+---
+
+## Phase 6: Create Content Nodes
+
+Only run after all required types are confirmed in Phase 3.
+
+### Creation order (dependency-safe)
+
+1. Taxonomy terms (done in Phase 4)
+2. Media/images — upload before nodes that reference them
+3. Independent nodes (e.g. `person`) — referenced by others
+4. Dependent nodes (e.g. `article` referencing `person`) — after step 3
+
+### Upload images
+
+```
+create_media(bundle: "image", name: "<descriptive name>", filename: "<file.jpg>",
+  metadata: { "alt": "<alt text>" })
+```
+
+Upload the file using the returned signed URL. Record the `target_id`.
+
+### Create nodes
+
+```
+create_node(bundle: "<type>", fields: {
+  "title": "<Title>",
+  "status": true,
+  "body": {
+    "value": "<p>HTML body</p>",
+    "format": "basic_html",
+    "summary": "<plain text summary>"
+  },
+  "field_<name>": "<value>",
+  "field_<ref_field>": { "target_id": <term-or-node-id> },
+  "path": { "alias": "/<url-path>" }
+})
+```
+
+Use `batch_create_nodes` when creating multiple nodes of the same bundle.
+
+HTML body content rules: only use `p strong em a ul ol li h2 h3 h4 blockquote`.
+
+### Pre-creation checklist
+
+- [ ] All required types confirmed (Phase 3)
+- [ ] Taxonomy terms created and IDs recorded (Phase 4)
+- [ ] Images uploaded and `target_id` values recorded
+
+---
+
+## Phase 7: Create Canvas Pages
+
+Canvas pages (`canvas_page` type) are layout containers that compose uploaded
+components. They are **not** a content store.
+
+Use `canvas_page` only for:
+
+- Section landing pages (e.g. /academics, /news)
+- Homepage
+- Utility pages (404, access denied)
+
+### Workflow for each page
+
+**1. Create the page:**
+
+```
+create_canvas_page(title: "<Page Title>", path: "/<path>")
+→ returns page_id
+```
+
+**2. Read available components:**
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://components")
+```
+
+**3. Add root-level components with real content from Phase 6:**
+
+```
+add_component_to_page(page_id: <id>, component_id: "js.<machine_name>", props: {
+  "<prop>": "<real value from crawled content>"
+})
+→ returns new_instance_id
+```
+
+**4. Add slotted children (if needed):**
+
+```
+add_component_to_page(
+  page_id: <id>,
+  component_id: "js.<child_component>",
+  parent_instance_id: "<parent-instance-id>",
+  slot: "<slot-name>",
+  props: { ... }
+)
+```
+
+**5. Publish:**
+
+```
+ReadMcpResourceTool(server: "source-mcp", uri: "canvas://auto-saves")
+→ get autosave_key and data_hash
+
+publish_auto_saves(autosaves: [{ autosave_key: "canvas_page:<id>:en", data_hash: "..." }])
+```
+
+---
+
+## Common Pitfalls
+
+1. **Missing content type — do not fall back to `page`**: If source MCP is
+   connected, auto-create the type via `create_content_type` +
+   `add_field_to_content_type`. If not connected, output the Content Type
+   Checklist and pause. Resume only after the user confirms types exist.
+
+2. **Menu links not available via MCP**: Ask the user to create menu items
+   manually at `/admin/structure/menu/manage/main`.
+
+3. **`eval` with arrow functions fails in playwright-cli**: Use `snapshot`
+   instead, then read the generated YAML file to extract content.
+
+4. **Path alias silently ignored**: After creating a node, verify the alias was
+   applied. If not, ask the user to set it in the Drupal UI.
+
+5. **Taxonomy references before terms exist**: Always create taxonomy terms
+   first and record IDs before creating nodes that reference them.
+
+6. **Hardcoding content types**: Never assume which types are needed. Always
+   derive them from the actual source analysis (crawl or Figma).
+
+7. **Figma-only with no content data**: When only a Figma file is provided,
+   produce the CT checklist and taxonomy plan but skip node creation (Phase 6).
+   Note clearly that real content data is needed before nodes can be created.
+
+8. **Figma annotations vs real fields**: Figma frames may show placeholder text
+   ("Lorem ipsum", "John Doe"). Do not treat placeholder values as real content
+   — they define the field structure only. Real values come from the live site
+   crawl or user-supplied data.
+
+---
+
+## Manual Steps Summary
+
+At the end of every migration run, always output this block. It tells the user
+exactly what the automation **could not do** and what still needs manual action
+in Drupal before the site is fully functional.
+
+Only include rows that apply to the current run.
+
+---
+
+### ⚠️ Manual Steps Required in Drupal
+
+The following tasks cannot be automated via source MCP and must be completed
+manually.
+
+**What source MCP handles automatically (no manual action needed):**
+
+- ✅ Content type creation (`create_content_type`)
+- ✅ Adding fields to content types (`add_field_to_content_type`)
+- ✅ Taxonomy term creation in existing vocabularies (`get_or_create_term`)
+- ✅ Content nodes, media, Canvas pages
+
+**What requires manual action:**
+
+| Task                                                           | Drupal path                                     | Notes                                                       |
+| -------------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| **Vocabulary creation** (if new vocabularies needed)           | `/admin/structure/taxonomy/add`                 | List each vocabulary name discovered in the crawl           |
+| **Menu creation** (if menus don't exist yet)                   | `/admin/structure/menu/add`                     | List each menu machine name the site needs                  |
+| **Menu links**                                                 | `/admin/structure/menu/manage/<menu-name>`      | List the links extracted in Phase 2 (label + path + parent) |
+| **JSON:API exposure** (if new content types were auto-created) | `/admin/config/services/jsonapi/resource_types` | Expose each new `node--<type>` resource                     |
+
+**For components that fetch from Drupal menus (e.g. header, footer):** These
+components include a static fallback array that renders immediately. Once you
+create the corresponding Drupal menus and add links, the components will
+automatically switch to live Drupal-managed navigation — no code change needed.

--- a/.agents/skills/visual-qa-loop/SKILL.md
+++ b/.agents/skills/visual-qa-loop/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: visual-qa-loop
+description:
+  Autonomous visual QA loop that verifies built Canvas components match their
+  design reference, iterates until they do, then validates and uploads to
+  Canvas. Use after components are built. Triggers when the user says "check if
+  it matches", "verify visually", "qa the components", "does it match the
+  design", or after a build step to close the loop automatically. Requires
+  playwright-cli; Figma MCP optional.
+metadata:
+  mcp-server: figma, figma-desktop
+allowed-tools: Bash(playwright-cli:*)
+---
+
+# Visual QA Loop
+
+An autonomous loop that screenshots each component in Canvas Workbench, compares
+it against the design reference, fixes any gaps, and repeats until parity is
+reached — then validates and uploads to Canvas.
+
+## MANDATORY CHECKLIST
+
+> ⛔ A component is **NOT** considered "matched" until ALL of the following are
+> done for it. Do not skip any item, even if it "looks fine":
+>
+> - [ ] Reference screenshot taken from live site at correct scroll position
+> - [ ] Style manifest extracted from live site (Step 3B-extra)
+> - [ ] Workbench component preview screenshotted at 1440×900
+> - [ ] Style manifest extracted from Workbench preview (Step 5.2)
+> - [ ] Screenshot comparison completed (Step 5.1)
+> - [ ] Numeric style manifest diff completed (Step 5.2) — every mismatch > 2px
+>       is a discrepancy that must be fixed
+> - [ ] At least one full fix-and-recheck iteration performed if ANY discrepancy
+>       was found
+>
+> Declaring "matched" after only a screenshot glance is **not acceptable**.
+
+## Reference Source
+
+Determine the reference type from how the build was initiated:
+
+- **Figma URL was provided** → use `get_screenshot` from the Figma MCP for each
+  component's node
+- **Live site URL was provided** → use playwright-cli to screenshot the
+  corresponding section of the live page
+
+Keep the reference screenshot(s) accessible throughout the loop. They are the
+source of truth.
+
+---
+
+## Step 1: Ensure Workbench Is Running
+
+Follow the `canvas-workbench` skill to start or reuse the local Workbench dev
+server. In this project, run:
+
+```bash
+npm run dev
+```
+
+Read the startup output and note the local URL it prints (typically
+`http://localhost:5173`). Wait until Workbench responds at that URL before
+continuing.
+
+---
+
+## Step 2: Identify Components and Their Preview States
+
+For each component being QA'd:
+
+1. Locate the component folder at `src/components/<component_name>/`
+2. Check whether a `mocks.json` file exists alongside `index.jsx` and
+   `component.yml`. If it does, read it to find the named preview states (e.g.,
+   `Default`, `WithButton`). If not, Workbench provides a built-in `Default`
+   state from `component.yml` example values.
+3. In Workbench, the component preview is accessible by navigating to the
+   component via the Workbench UI at the URL printed at startup. Use
+   `canvas-workbench/references/components.md` for the Workbench component
+   review flow.
+4. The clean preview URL for playwright-cli screenshots:
+   `<workbench-url>/?component=<component-name>&state=Default` (substitute the
+   actual Workbench URL and state name)
+
+---
+
+## Step 3: Get the Reference Screenshot and Styles
+
+### Option A — Figma reference
+
+For each component node that was used during the build:
+
+```
+get_screenshot(fileKey=":fileKey", nodeId=":nodeId")
+```
+
+If you have a page-level Figma node, get the full page screenshot and crop
+mentally to the relevant section during comparison.
+
+### Option B — Live site reference
+
+Open the live site at 1440px width and screenshot the section that corresponds
+to the component:
+
+```bash
+playwright-cli open <live-site-url> --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli eval "window.scrollTo(0, <scrollY-of-section>)"
+playwright-cli screenshot --filename=reference-<component-name>.png
+```
+
+Store the filename for use in comparison.
+
+### 3B-extra — Extract computed styles from the live site (MANDATORY)
+
+> ⛔ Do not skip this step. A screenshot alone is not sufficient for QA. You
+> must extract and save the style manifest so it can be diffed against the
+> Workbench preview in Step 5.2.
+
+After taking the screenshot, extract the computed styles for the key elements in
+each section. Identify the most important selectors (heading, body text, button,
+container, card) and run:
+
+```bash
+playwright-cli eval "
+const results = {};
+const targets = {
+  heading: 'h1, h2, [class*=\"heading\"], [class*=\"title\"]',
+  body: 'p, [class*=\"body\"], [class*=\"text\"]',
+  button: 'a[class*=\"btn\"], button, a[class*=\"button\"]',
+  nav: 'nav a, [class*=\"nav\"] a',
+  card: '[class*=\"card\"]',
+  container: '[class*=\"container\"], main > div',
+};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  results[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    paddingTop: s.paddingTop,
+    paddingBottom: s.paddingBottom,
+    paddingLeft: s.paddingLeft,
+    paddingRight: s.paddingRight,
+    marginTop: s.marginTop,
+    marginBottom: s.marginBottom,
+    borderRadius: s.borderRadius,
+    textTransform: s.textTransform,
+  };
+}
+JSON.stringify(results, null, 2)
+"
+```
+
+Save this output as your **style manifest** for this component. Reference it
+during comparison to catch exact numeric mismatches.
+
+Also extract the color palette used:
+
+```bash
+playwright-cli eval "
+const colors = new Set();
+document.querySelectorAll('*').forEach(el => {
+  const s = getComputedStyle(el);
+  if (s.backgroundColor && s.backgroundColor !== 'rgba(0, 0, 0, 0)' && s.backgroundColor !== 'transparent')
+    colors.add(s.backgroundColor);
+  if (s.color) colors.add(s.color);
+});
+JSON.stringify([...colors].slice(0, 30))
+"
+```
+
+---
+
+## Step 4: Screenshot the Workbench Preview
+
+```bash
+playwright-cli open <workbench-url>/?component=<component-name>&state=Default --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli screenshot --filename=workbench-<component-name>.png
+```
+
+---
+
+## Step 5: Visual Comparison
+
+### 5.1 — Screenshot comparison
+
+Look at both screenshots side by side and evaluate:
+
+- **Layout**: alignment, spacing, padding, margins
+- **Typography**: font family, size, weight, line height, color
+- **Colors**: backgrounds, text, borders, shadows
+- **Components**: icons, images, buttons, badges
+- **Responsiveness**: does it look right at 1440px?
+
+### 5.2 — Style manifest comparison (live site only)
+
+If a style manifest was collected in Step 3B-extra, also extract computed styles
+from the Workbench preview to compare numerically:
+
+```bash
+playwright-cli open <workbench-url>/?component=<component-name>&state=Default --browser=chrome
+playwright-cli resize 1440 900
+playwright-cli eval "
+const results = {};
+const targets = {
+  heading: 'h1, h2, [class*=\"heading\"], [class*=\"title\"]',
+  body: 'p, [class*=\"body\"]',
+  button: 'a, button',
+  card: '[class*=\"card\"]',
+  container: 'div > div',
+};
+for (const [name, selector] of Object.entries(targets)) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+  const s = getComputedStyle(el);
+  results[name] = {
+    fontFamily: s.fontFamily,
+    fontSize: s.fontSize,
+    fontWeight: s.fontWeight,
+    lineHeight: s.lineHeight,
+    letterSpacing: s.letterSpacing,
+    color: s.color,
+    backgroundColor: s.backgroundColor,
+    paddingTop: s.paddingTop,
+    paddingBottom: s.paddingBottom,
+    paddingLeft: s.paddingLeft,
+    paddingRight: s.paddingRight,
+    borderRadius: s.borderRadius,
+    textTransform: s.textTransform,
+  };
+}
+JSON.stringify(results, null, 2)
+"
+```
+
+Diff the two style manifests value-by-value. Every numeric mismatch (font-size,
+padding, line-height, color) is a discrepancy to fix — even if the screenshot
+looks "close enough".
+
+### 5.3 — Report discrepancies
+
+List every discrepancy found. Be specific (e.g., "heading font-size is 24px but
+reference shows 32px", "button background is blue-500 but should be blue-700",
+"missing 48px top padding on section").
+
+If no discrepancies are found → skip to
+[Step 7: Validate and Upload](#step-7-validate-and-upload).
+
+---
+
+## Step 6: Fix and Re-Check
+
+1. Open the component source at `src/components/<component_name>/index.jsx`
+2. Apply fixes for each discrepancy found in Step 5
+3. Save the file (Workbench hot-reloads automatically)
+4. Wait 2 seconds for hot reload to complete
+5. Re-screenshot:
+   ```bash
+   playwright-cli reload
+   playwright-cli screenshot --filename=workbench-<component-name>.png
+   ```
+6. Return to **Step 5** and compare again
+
+**Iteration limit:** If after 5 iterations the component still has significant
+discrepancies, stop and report the remaining gaps to the user rather than
+continuing to loop. Minor pixel-level differences (≤2px) are acceptable.
+
+---
+
+## Step 7: Validate and Upload
+
+Once visual parity is achieved for all components:
+
+### 7.1 — Validate
+
+Run the `nebula-component-validation` skill to fix formatting, linting, and
+Canvas requirements:
+
+```bash
+npm run code:fix
+```
+
+Resolve any remaining errors before proceeding.
+
+### 7.2 — Upload
+
+Run the `canvas-component-push` skill to push to the Canvas site.
+
+---
+
+## Multi-Component Pages
+
+When QA-ing a page preview (e.g., `pages/homepage.json`):
+
+1. Open the page preview in Workbench:
+   ```bash
+   playwright-cli open <workbench-url>/?page=homepage
+   playwright-cli resize 1440 900
+   playwright-cli eval "document.documentElement.scrollHeight"
+   ```
+2. For each 900px section, scroll and screenshot
+3. Compare section-by-section against the reference
+4. Fix individual component files as needed
+5. Re-screenshot affected sections after each fix
+
+---
+
+## Example Run
+
+**Input:** Hero Banner component was built from a Figma URL.
+
+1. Get Figma screenshot for the Hero Banner node
+2. Open Workbench preview:
+   `<workbench-url>/?component=hero-banner&state=Default`
+3. Screenshot at 1440px
+4. Compare: "heading is 24px but Figma shows 40px; background image is not full
+   bleed"
+5. Fix `src/components/hero_banner/index.jsx`
+6. Re-screenshot → compare again
+7. Match achieved → run `npm run code:fix` → upload


### PR DESCRIPTION
## Add orchestration pipeline skills and update existing component skills

### Summary

This PR adds 7 new skills and updates 2 existing skills to support a complete end-to-end Canvas site-building workflow - from a source URL to live assembled pages - covering component building, visual QA, content migration, and page assembly.

---


## New Skills


### Orchestration Pipelines


| Skill | Purpose |
|---|---|
| `full-site-build` | End-to-end site build: components + content in parallel, then Canvas page assembly |
| `build-and-deploy` | Component-only pipeline: build → visual QA → validate → push → page assembly |
| `build-from-url` | Entry point for any URL; auto-detects Figma vs web and routes accordingly |
| `site-content-migration` | Structured content migration from any source into a Canvas/Drupal site |



**`full-site-build`**

- Accepts a source URL or Figma URL; runs Track A (component build) and Track B (content migration) in parallel, then executes Phase C to assemble Canvas pages wiring real components to real content.
- Phase A5 uploads all images to Drupal media and wires them to component instances before pages are published.
- Auto-creates missing Drupal content types when source MCP is connected; pauses and requests user confirmation when it is not.


**`build-and-deploy`**

- Four phases: (1) build from URL, (2) visual QA loop (mandatory, 5-iteration max), (3) validate via `code:fix` + re-QA + push, (4) build Canvas page via source MCP.
- Phase 2 and Phase 4 are never skipped, regardless of prior phase outcome.
- Outputs a structured final report covering component table, page assembly status, and any required manual Drupal steps.


**`build-from-url`**

- Figma URLs route directly to the build phase; all other URLs run Playwright capture first (Phase 1: open at 1440×900, dismiss overlays, extract style manifest and tokens).
- Optionally captures to Figma (Phase 1.6) when Figma MCP is connected; falls back to Playwright-only reference when it is not.
- Phases 2a/2b build from Figma or Playwright reference respectively; Phase 3 runs visual QA.



**`site-content-migration`**

- Seven phases: (1) discover Canvas site schema, (2) analyze source, (3) content-type gate, (4) taxonomy terms, (5) menus (manual — not MCP-supported), (6) content nodes, (7) Canvas page assembly.
- Content types are derived from the actual source crawl; nothing is hardcoded.
- Phase 3 auto-creates content types when source MCP is connected; pauses for user input when it is not.



---



### Utilities


**`visual-qa-loop`**

- Takes screenshots and extracts style manifests from both the live site and Workbench preview at 1440×900.
- Applies numeric diff with ≤2 px / 2% tolerance; runs up to 5 iterations per component.
- A component is only marked "Matched" when both the screenshot and style manifest pass. Mandatory before any upload.


**`content-management`**

- Covers all Canvas content operations via source MCP: nodes (create/update/batch), taxonomy terms (`get_or_create_term`), media/image uploads (signed URL), Canvas pages (create/update/publish via autosave), slotted component placement, and HTML body formatting.
- No CLI credentials or JSON:API authentication required.



**`playwright-cli`**

- Browser automation reference skill covering: navigation, click/fill/type/select/drag/hover, snapshot/screenshot, resize, upload, dialog handling, keyboard (`press`), multi-tab management, cookie/localStorage/sessionStorage access, network mocking, and CSS injection.



---



## Updated Skills



### `canvas-component-metadata`

- Added mandatory **"Array and object data — decision gate"** section: Canvas does not support `type: array` or inline `properties` objects in `component.yml`. Arrays and objects must be decomposed into named slots and child components. Silently dropping an array prop with no replacement is never acceptable; `JSON.parse` string serialization is explicitly banned. Includes a 5-item decomposition checklist.



### `canvas-data-fetching`

- Added **"Navigation / Menu Components"** section with a dual-implementation pattern: define a `FALLBACK_LINKS` constant (renders immediately in Workbench and on new sites) and fetch live Drupal menu via SWR using `JsonApiClient.getResource('menu_items', menuName)` + `sortMenu()`.
- `menuName` is registered as a prop in `component.yml`; setting `menuName = null` disables fetching (SWR key is null).
- After building a nav component, the skill instructs adding a note to create the corresponding Drupal menu at `/admin/structure/menu/add`.


---



## Pipeline Architecture


The two entry-point skills (`build-from-url` for components only, `full-site-build` for end-to-end) share the same two-track structure. Track A and Track B start concurrently; page assembly only begins once both are complete.

```

Source URL  ──────────────────────────────────────────────────────────────────┐

  (web URL or Figma URL)                                                       │

  Entry: build-from-url / full-site-build                                      │

               │                                                               │

               ├─ Track A (Visual) ────────────────────────────────────────────┤

               │     scrape reference screenshots (playwright-cli)             │

               │     classify static vs. dynamic components                   │

               │     scaffold components (nebula-component-creation)           │

               │     implement design tokens (implement-design if Figma MCP)   │

               │     visual-qa-loop ← mandatory, up to 5 iterations           │

               │     validate (npm run code:fix)                               │

               │     visual-qa-loop again ← mandatory post-validation          │

               │     upload components + global CSS (canvas-component-push)    │

               │     upload images → Drupal media, wire to component instances │

               │                                                               │

               └─ Track B (Content) — B1–B2 concurrent with A; B3+ after upload

                     discover Canvas schema (source MCP)                       

                     crawl source (playwright-cli)                             

                     Content Type Gate:                                        

                       source-mcp connected → auto-create types + fields       

                       source-mcp absent    → pause, output checklist          

                     create taxonomy terms (source MCP)                        

                     create menu items (manual — not MCP-supported)            

                     create content nodes (source MCP)                         

                     wire SWR for dynamic components → re-upload if needed     

                                       │                                       

               ───────────────────────┘                                        

               Merge: content-management → assemble Canvas pages               

                      playwright-cli → verify live pages                       

```



### Blocking conditions per phase



| Phase | Skill | Blocks on |
|---|---|---|
| Capture | `build-from-url` (Playwright) | None — falls back gracefully if Figma MCP absent |
| Build | `nebula-component-creation` | Requires capture reference |
| Visual QA | `visual-qa-loop` | Must pass before upload; max 5 iterations |
| Validate + push | `code:fix` + `canvas-component-push` | QA must be green |
| Image upload | `content-management` (signed URL) | Component push must succeed |
| Content migration | `site-content-migration` | Runs in parallel with Track A |
| Page assembly | `content-management` (Canvas pages) | Both tracks must complete |


---


## Supported Flows


```

build-from-url (any URL)

  ├── Figma URL  → Phase 2a: build from Figma reference → Phase 3: visual QA

  └── Web URL   → Phase 1: Playwright capture (1440×900) → [Phase 1.6: export to Figma]

                   → Phase 2b: build from Playwright reference → Phase 3: visual QA



build-and-deploy (component pipeline only)

  URL → build-from-url → visual-qa-loop (≤5 iter)

      → code:fix → re-QA → canvas-component-push

      → content-management (Canvas page assembly)



full-site-build (end-to-end)

  URL ──┬── Track A: component build + upload + image wiring ──┐

        └── Track B: content type gate → taxonomy → nodes     ──┴── content-management page assembly → publish

```



---



## Example Test Workflows


- **Web URL, Figma MCP connected** — `build-from-url` captures with Playwright, exports to Figma, builds from Figma reference; `visual-qa-loop` confirms match; component is pushed to Canvas.
- **Web URL, no Figma MCP** — same flow but Figma export is skipped; build uses Playwright reference only; QA and push proceed normally.
- **Figma URL direct** — `build-from-url` skips Playwright capture entirely; jumps to Phase 2a; QA and push complete end-to-end.
- **Component with image props** — `full-site-build` Phase A5 uploads images via `content-management` signed-URL flow and wires them to component instances before page publish.
- **Nav component build** — `canvas-data-fetching` nav pattern used: `FALLBACK_LINKS` renders in Workbench immediately; SWR fetch activates on live site; `menuName = null` disables fetch when unset.
- **New site, no existing content types** — `site-content-migration` Phase 3 gate triggers; if source MCP is connected, content types are auto-created; if not, pipeline pauses for user confirmation before continuing.
- **Array prop encountered in component.yml** — `canvas-component-metadata` decision gate fires; prop is decomposed into named slots and a child component; no silent removal, no JSON string workaround.
- **Full site build from live URL** — `full-site-build` runs Track A and Track B in parallel; Phase C assembles Canvas pages only after both tracks complete; published pages reference live components and migrated content.
- **QA loop reaches iteration limit** — `visual-qa-loop` reports failure after 5 iterations; `build-and-deploy` surfaces the diff detail and halts before push; no component is uploaded in a failing state.
- **`.claude/skills/` path resolution** — skills previously duplicated in `.claude/skills/` and `.agents/skills/` now resolve to a single copy in `.agents/skills/`; `.claude/skills/` retains only the 7 new pipeline/orchestration skills.


---

# Source MCP — Tasks Reference

## Tasks Handled Only by Source MCP

### Schema / Content Type Management

| Task | MCP Tool |
|---|---|
| Discover existing content types | `ReadMcpResourceTool(uri: "drupal://content-types")` |
| Discover existing taxonomy vocabularies | `list_entities(entity_type: "taxonomy_vocabulary")` |
| Auto-create a missing content type | `create_content_type(machine_name, label, workflow)` |
| Add fields to a content type | `create_field(...)` |

### Taxonomy

| Task | MCP Tool |
|---|---|
| Create taxonomy terms (in existing vocabularies) | `get_or_create_term(vid, name)` |

### Content Nodes

| Task | MCP Tool |
|---|---|
| Create a content node | `create_node(bundle, fields)` |
| Update an existing node | `update_node(entity_id, fields)` |
| Bulk-create nodes of the same bundle | `batch_create_nodes(...)` |

### Media

| Task | MCP Tool |
|---|---|
| Upload an image / create a media entity | `create_media(bundle, name, filename, metadata)` |
| Upload a remote video | `create_remote_video(...)` |
| Wire image prop to a component instance | `update_component_props(page_id, instance_id, { image_prop: { target_id } })` |

### Canvas Pages

| Task | MCP Tool |
|---|---|
| List existing Canvas pages | `list_entities(entity_type: "canvas_page")` |
| Read available uploaded components | `ReadMcpResourceTool(uri: "canvas://components")` |
| Create a Canvas page | `create_canvas_page(title, path)` |
| Update page title/path | `update_canvas_page(page_id, title, path)` |
| Read current page layout | `get_page_layout(page_id)` |
| Place a component on a page | `add_component_to_page(page_id, component_id, props)` |
| Place a slotted child component | `add_component_to_page(..., parent_instance_id, slot)` |
| Get the autosave key + data hash | `ReadMcpResourceTool(uri: "canvas://auto-saves")` |
| Publish a Canvas page | `publish_auto_saves(autosaves: [...])` |

---

## What Source MCP Cannot Do (manual steps)

These are explicitly outside MCP scope across all skills:

| Task | Where to do it manually |
|---|---|
| Create menus | `/admin/structure/menu/add` |
| Create menu links | `/admin/structure/menu/manage/<menu-name>` |
| Create taxonomy vocabularies (the vocabulary itself, not terms) | `/admin/structure/taxonomy/add` |
| Expose content types to JSON:API | Drupal config UI |
| Configure editorial workflows (if non-default) | Drupal config UI |
