### PR TITLE
Refine guidance around validation, visual verification, and Canvas push behavior

### DIFF
--- a/.agents/skills/canvas-component-definition/SKILL.md
+++ b/.agents/skills/canvas-component-definition/SKILL.md
@@ -82,6 +82,7 @@ Evaluate using companion skills in this order.
 6. Downstream validation and visual review
    - Ensure `Default` examples and any authored `mocks.json` states are
      sufficient for downstream visual review.
-7. `canvas-component-push`
-   - Use after implementation is complete and validated, when pushing changes
-     and recovering from push failures.
+7. `canvas-component-push` (optional)
+   - Use only when the user explicitly asks to push/publish/sync components to
+     Canvas.
+   - Do not run push automatically after implementation or static validation.

--- a/.agents/skills/canvas-component-definition/SKILL.md
+++ b/.agents/skills/canvas-component-definition/SKILL.md
@@ -49,7 +49,7 @@ component source and metadata:
   example value for each prop from `component.yml`
 
 Rendered-output changes are incomplete unless the component has sufficient
-Workbench preview coverage for downstream validation and visual review.
+Workbench preview coverage.
 
 ## Naming guidance
 
@@ -79,9 +79,9 @@ Evaluate using companion skills in this order.
 5. `canvas-data-fetching`
    - Use when fetching/rendering Drupal content with JSON:API, SWR, includes,
      and filter patterns.
-6. Downstream validation and visual review
+6. Preview coverage readiness
    - Ensure `Default` examples and any authored `mocks.json` states are
-     sufficient for downstream visual review.
+     sufficient for review of the requested change.
 7. `canvas-component-push` (optional)
    - Use only when the user explicitly asks to push/publish/sync components to
      Canvas.

--- a/.agents/skills/canvas-component-push/SKILL.md
+++ b/.agents/skills/canvas-component-push/SKILL.md
@@ -2,11 +2,18 @@
 name: canvas-component-push
 description:
   Push validated Canvas component changes to Drupal Canvas and recover from
-  common push failures. Use after component work is complete and validated.
-  Handles dependency-related push failures that require retry.
+  common push failures. Use only when the user explicitly requests a
+  push/publish/sync action. Handles dependency-related push failures that
+  require retry.
 ---
 
-## Push to Canvas
+## Activation guard
+
+Run this skill only when the user explicitly asks to push, publish, sync, or
+upload components to Canvas.
+
+Do not run this skill automatically after component edits, validation, or task
+completion.
 
 Before pushing, confirm the user has Drupal Canvas CLI installed and configured
 for their target site.

--- a/.agents/skills/canvas-page-definition/SKILL.md
+++ b/.agents/skills/canvas-page-definition/SKILL.md
@@ -55,7 +55,7 @@ definitions that can be previewed in Workbench and synced with Canvas via the
 CLI.
 
 Authored page work is incomplete unless the page is previewable from the
-configured `pagesDir` and ready for downstream validation and visual review.
+configured `pagesDir` and ready for validation.
 
 ## Page file format
 

--- a/.agents/skills/canvas-workbench/SKILL.md
+++ b/.agents/skills/canvas-workbench/SKILL.md
@@ -84,9 +84,9 @@ instead of starting a second instance.
 
 ## Verification workflow
 
-Workbench is the runtime surface used by downstream visual review workflows.
-When verification is iterative, reuse the same Workbench server and preview
-route across fix/review loops.
+Workbench is the runtime surface for local preview verification. When
+verification is iterative, reuse the same Workbench server and preview route
+across fix/review loops.
 
 Use Workbench as part of the normal implementation loop:
 

--- a/.agents/skills/nebula-component-validation/SKILL.md
+++ b/.agents/skills/nebula-component-validation/SKILL.md
@@ -32,10 +32,4 @@ This runs Prettier and ESLint with auto-fix, ensuring:
 
 If errors remain after auto-fix, address them manually and re-run until passing.
 
-When the task changes rendered output, this skill ends at static validation. Do
-not run browser-based visual verification automatically.
-
-Run `nebula-visual-verification` only when the user explicitly asks for visual
-verification. When explicitly requested, run it only after static validation
-passes. If visual verification fails, fix the changed surface, rerun static
-validation when code changed, and re-run `nebula-visual-verification`.
+When the task changes rendered output, this skill ends at static validation.

--- a/.agents/skills/nebula-component-validation/SKILL.md
+++ b/.agents/skills/nebula-component-validation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: nebula-component-validation
 description:
-  Validate components before uploading to Canvas. Use after creating or
-  modifying components, and after page work that changes rendered output, before
-  considering work complete. Runs `npm run code:fix` for static validation.
+  Validate components after creating or modifying components, and after page
+  work that changes rendered output, before considering work complete. Runs `npm
+  run code:fix` for static validation.
 ---
 
 # Validate

--- a/.agents/skills/nebula-component-validation/SKILL.md
+++ b/.agents/skills/nebula-component-validation/SKILL.md
@@ -3,8 +3,7 @@ name: nebula-component-validation
 description:
   Validate components before uploading to Canvas. Use after creating or
   modifying components, and after page work that changes rendered output, before
-  considering work complete. Runs `npm run code:fix` and the repo-local visual
-  verification workflow.
+  considering work complete. Runs `npm run code:fix` for static validation.
 ---
 
 # Validate
@@ -33,9 +32,10 @@ This runs Prettier and ESLint with auto-fix, ensuring:
 
 If errors remain after auto-fix, address them manually and re-run until passing.
 
-When the task changes rendered output, start or reuse Canvas Workbench and run
-`nebula-visual-verification` against the changed component or page after static
-validation passes. If visual verification fails, fix the changed surface, rerun
-static validation when code changed, and re-run `nebula-visual-verification`.
-Finish only when the verification loop passes or is stuck under the verifier's
-blocker rules.
+When the task changes rendered output, this skill ends at static validation. Do
+not run browser-based visual verification automatically.
+
+Run `nebula-visual-verification` only when the user explicitly asks for visual
+verification. When explicitly requested, run it only after static validation
+passes. If visual verification fails, fix the changed surface, rerun static
+validation when code changed, and re-run `nebula-visual-verification`.

--- a/.agents/skills/nebula-visual-verification/SKILL.md
+++ b/.agents/skills/nebula-visual-verification/SKILL.md
@@ -2,14 +2,22 @@
 name: nebula-visual-verification
 description:
   Focused visual QA for changed Canvas components and pages in local Canvas
-  Workbench. Use when (1) A component or page change needs post-change visual
-  review, (2) Codex needs to verify contrast, spacing, layout, overflow,
-  responsive behavior, typography, image/copy fit, or other visual issues, or
-  (3) A changed Workbench surface needs an `agent-browser` verify/fix/reverify
-  loop until it passes or the work is stuck.
+  Workbench. Use only when the user explicitly asks for visual verification,
+  visual QA, or Workbench rendering review of a changed component or page.
 ---
 
 # Visual verification
+
+## Activation guard
+
+Run this skill only when the user explicitly requests visual verification.
+
+Do not run this skill automatically after component or page changes, and do not
+infer consent from generic requests such as "validate", "run checks", or "finish
+the task".
+
+If explicit visual verification was not requested, do not run browser steps and
+report that visual verification was not performed.
 
 Use this skill for the changed Workbench target only. Do not broaden into full
 app QA unless the user explicitly asks for exploratory testing; use `dogfood`

--- a/.agents/skills/nebula-visual-verification/SKILL.md
+++ b/.agents/skills/nebula-visual-verification/SKILL.md
@@ -44,6 +44,22 @@ browser automation for this skill.
 If the changed surface is not reviewable in Workbench, stop immediately. Missing
 preview coverage is a blocker; do not treat the task as visually verified.
 
+## Mandatory deterministic check
+
+For every visual verification run, run the browser-side helper script below for
+each required target/state/viewport combination before claiming success:
+
+```bash
+node .agents/skills/nebula-visual-verification/scripts/collect-visual-signals.js \
+  --scope body \
+  --sample-limit 60 \
+  | agent-browser --session "$SESSION" eval --stdin
+```
+
+If this helper is not executed, the verification is incomplete and must be
+reported as not fully validated. Screenshots, manual inspection, and ad hoc
+`eval` checks do not replace this requirement.
+
 ## Target resolution
 
 - **Component work**: verify the changed `/component/<component-id>` route, any
@@ -69,21 +85,15 @@ Verify every target and named state at:
    interactions in this workflow.
 3. Resolve the exact review target and state list from the changed component or
    page.
-4. For each target/state/viewport combination:
+4. For each target/state/viewport combination, perform all of the following:
    - Open the preview route.
    - Wait for `networkidle` and for any obvious loading UI to settle.
    - Capture a screenshot and an annotated screenshot when a failure needs to be
      documented.
    - Use `snapshot` for structural review.
-   - Run the browser-side helper script for deterministic signals:
-
-     ```bash
-     node .agents/skills/nebula-visual-verification/scripts/collect-visual-signals.js \
-       --scope body \
-       --sample-limit 60 \
-       | agent-browser --session "$SESSION" eval --stdin
-     ```
-
+   - Run the mandatory deterministic check command from "Mandatory deterministic
+     check".
+   - Review the helper output before deciding pass/fail.
    - Use `get styles`, `get box`, and focused `eval` calls when a specific
      element needs more evidence.
 
@@ -120,6 +130,16 @@ refactor or unrelated design rewrite.
   may fetch a better replacement. Otherwise stay conservative and avoid
   speculative image churn.
 
+## Completion gate
+
+Do not say the changed surface "passed", "was verified", or "is visually
+validated" unless the helper script was run for every required
+target/state/viewport combination and the results were reviewed.
+
+If screenshots or manual inspection were done without the helper script, report
+that outcome as "manual review only" or "partial verification", not full visual
+verification.
+
 ## Stuck rules
 
 Stop the auto-fix loop and report a blocker when any of these are true:
@@ -128,9 +148,25 @@ Stop the auto-fix loop and report a blocker when any of these are true:
 - There is no material code change between loops.
 - Workbench will not start or cannot render the changed target.
 - Preview coverage is missing.
+- `collect-visual-signals.js` cannot be run successfully for the required
+  target/state/viewport combinations.
 - The remaining failure needs a product decision or an unresolved image source.
 
 When stuck, explain the blocker clearly. Do not claim the task passed.
+
+## Required closeout
+
+Every verification closeout must include:
+
+- target route(s) reviewed
+- viewport(s) reviewed
+- whether `collect-visual-signals.js` was run
+- a short summary of deterministic findings
+- a short summary of manual visual findings
+
+If the helper script was not run, explicitly state:
+
+`Deterministic verification was not completed.`
 
 ## Artifacts
 

--- a/.agents/skills/nebula-visual-verification/SKILL.md
+++ b/.agents/skills/nebula-visual-verification/SKILL.md
@@ -19,7 +19,18 @@ for that.
 
 - Checklist and pass/fail heuristics: `references/checklist.md`
 - Browser-side signal collector: `scripts/collect-visual-signals.js`
+- Browser CLI command guide: `agent-browser` skill
 - Start or reuse Canvas Workbench with the `canvas-workbench` skill
+
+## Tooling note
+
+Always consult the `agent-browser` skill before running browser verification for
+this skill. Treat it as the canonical source for command semantics, session
+behavior, and interaction patterns.
+
+Do not assume a separate browser tool wrapper is required. If `agent-browser` is
+available in the environment, run it through the shell and treat that as valid
+browser automation for this skill.
 
 ## Preconditions
 
@@ -54,9 +65,11 @@ Verify every target and named state at:
 
 1. Use the `canvas-workbench` skill to start or reuse Canvas Workbench and
    record the base URL.
-2. Resolve the exact review target and state list from the changed component or
+2. Review the `agent-browser` skill and use its command patterns for all browser
+   interactions in this workflow.
+3. Resolve the exact review target and state list from the changed component or
    page.
-3. For each target/state/viewport combination:
+4. For each target/state/viewport combination:
    - Open the preview route.
    - Wait for `networkidle` and for any obvious loading UI to settle.
    - Capture a screenshot and an annotated screenshot when a failure needs to be
@@ -74,16 +87,12 @@ Verify every target and named state at:
    - Use `get styles`, `get box`, and focused `eval` calls when a specific
      element needs more evidence.
 
-4. Compare the rendered result against the checklist in
+5. Compare the rendered result against the checklist in
    `references/checklist.md`.
-5. If all checks pass for every required state and viewport, finish.
-6. If any check fails, fix the changed surface and direct dependencies only,
+6. If all checks pass for every required state and viewport, finish.
+7. If any check fails, fix the changed surface and direct dependencies only,
    rerun static validation when code changed, and re-run this skill against the
    same routes, states, and viewports.
-
-Prefer the direct `agent-browser` binary when it is available in the current
-environment. Fall back to `npx agent-browser` only if the direct binary is not
-available.
 
 ## Auto-fix loop
 

--- a/.agents/skills/nebula-workbench-pages/SKILL.md
+++ b/.agents/skills/nebula-workbench-pages/SKILL.md
@@ -18,7 +18,9 @@ when authoring real Workbench pages in `pages/`.
 
 Only pages in the canonical `pages/` directory are valid local verification
 targets in this repository. After creating or visually modifying a page, use
-`nebula-component-validation` to run repo-local validation and visual
+`nebula-component-validation` to run repo-local static validation.
+
+Run `nebula-visual-verification` only when the user explicitly asks for visual
 verification.
 
 Use `canvas-page-definition` for the generic page-spec contract, and

--- a/.agents/skills/nebula-workbench-pages/SKILL.md
+++ b/.agents/skills/nebula-workbench-pages/SKILL.md
@@ -20,9 +20,6 @@ Only pages in the canonical `pages/` directory are valid local verification
 targets in this repository. After creating or visually modifying a page, use
 `nebula-component-validation` to run repo-local static validation.
 
-Run `nebula-visual-verification` only when the user explicitly asks for visual
-verification.
-
 Use `canvas-page-definition` for the generic page-spec contract, and
 `canvas-workbench/references/pages.md` for the Workbench-specific page preview
 flow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,5 +15,5 @@ For all operations involving React components, the `component.yml` files, and
 
 ## Validation
 
-Use the `nebula-component-validation` skill for static validation and repo-local
-visual verification after rendered-output changes.
+Use the `nebula-component-validation` skill for static validation after
+rendered-output changes.


### PR DESCRIPTION
- make `canvas-component-push` opt-in, only when the user explicitly asks to push/publish/sync
- make `nebula-visual-verification` opt-in, only when the user explicitly asks for visual QA or Workbench review
- narrow `nebula-component-validation` to static validation (`npm run code:fix`) instead of bundling visual verification
- strengthen `nebula-visual-verification` with a mandatory deterministic `collect-visual-signals.js` check and stricter closeout requirements
- remove broader "downstream validation" wording from related skills and AGENTS guidance, replacing it with clearer preview/validation language