### PR TITLE
feat(agents): update canvas-page-definition skill to include information about page path and description

### DIFF
--- a/.agents/skills/canvas-page-definition/SKILL.md
+++ b/.agents/skills/canvas-page-definition/SKILL.md
@@ -156,15 +156,6 @@ exists, create it as a component before using it in a page spec.
 
 Validate every authored page before finishing.
 
-Use the published schema:
-
-`https://git.drupalcode.org/project/canvas/-/raw/1.x/packages/workbench/src/lib/schemas/page-spec.schema.json`
-
-Example with `ajv-cli`:
-
 ```bash
-npx ajv-cli validate \
-  --spec=draft2020 \
-  -s https://git.drupalcode.org/project/canvas/-/raw/1.x/packages/workbench/src/lib/schemas/page-spec.schema.json \
-  -d path/to/page.validation.json
+npx canvas validate
 ```

--- a/.agents/skills/canvas-page-definition/SKILL.md
+++ b/.agents/skills/canvas-page-definition/SKILL.md
@@ -26,6 +26,8 @@ Every Canvas page MUST satisfy all checks below:
   `canvas.config.json`; default `./pages`)
 - The page file is a JSON object
 - The page includes a non-empty `title`
+- The page includes a `path` that starts with `/` and is unique within the
+  project
 - The page includes an `elements` object with at least one element
 - Every element in `elements` includes a discovered component `type`
 - Any `slots` entries reference element IDs defined in the same file
@@ -62,7 +64,14 @@ configured `pagesDir` and ready for validation.
 Each page file must be a JSON object with:
 
 - `title`: the actual page title
+- `path`: the page's URL path (e.g., `/about`). Must start with `/` and be
+  unique within the project. Other pages link to this page using this value.
 - `elements`: an object of authored page elements
+
+The page file may also include:
+
+- `description`: a short plain-text summary of the page. Surfaced as page
+  metadata (e.g., for listings or SEO). Leave as an empty string if not set.
 
 Each entry in `elements` must include:
 
@@ -80,11 +89,17 @@ Use the discovered machine-readable component type for each element, such as
 `card`, `heading`, or `js.hero`, depending on what Workbench finds in the local
 project.
 
+## Linking between pages
+
+To link to another page in the project, reference the target page's `path`.
+
 ## Example
 
 ```json
 {
   "title": "About",
+  "path": "/about",
+  "description": "",
   "elements": {
     "hero": {
       "type": "js.hero",

--- a/examples/pages/homepage.json
+++ b/examples/pages/homepage.json
@@ -1,5 +1,7 @@
 {
   "title": "Homepage",
+  "path": "/home",
+  "description": "",
   "elements": {
     "cf8abf57-3d3f-4624-bc2c-773a5c28391f": {
       "type": "js.hero",


### PR DESCRIPTION
- update canvas-page-definition skill to include information about page path and description, including guidelines on how to link between pages
- update canvas-page-definition skill to use `canvas validate` for validating pages instead of ajv-cli

Depends on [#3585978: Include page paths and descriptions in the CLI push/pull commands](https://www.drupal.org/project/canvas/issues/3585978).