### PR TITLE
feat(logo): use themeAssets.logo.url from getSiteData() with SVG fallback

### DIFF
--- a/examples/components/logo/index.jsx
+++ b/examples/components/logo/index.jsx
@@ -1,10 +1,17 @@
 import { getSiteData } from 'drupal-canvas';
 
 const Branding = () => {
-  const { homeUrl, siteName } = getSiteData().branding;
+  const { branding, themeAssets } = getSiteData();
+  const { homeUrl, siteName } = branding;
+  const logoUrl = themeAssets?.logo?.url;
+
   return (
     <a href={homeUrl} aria-label={siteName} className="max-h-full">
-      <LogoIcon />
+      {logoUrl ? (
+        <img src={logoUrl} alt="" className="max-h-full" />
+      ) : (
+        <LogoIcon />
+      )}
       <div className="sr-only">{siteName}</div>
     </a>
   );


### PR DESCRIPTION
## Summary

- Updates `examples/components/logo/index.jsx` to read `themeAssets.logo.url` from `getSiteData()`
- Renders an `<img>` tag when the URL is present; falls back to the inline Acquia SVG when it is empty or not set
- Cannot be tested in Workbench until https://www.drupal.org/project/canvas/issues/3585327

## Test plan

- [ ] Verify logo renders inline SVG when `drupalSettings.canvasData.v0.themeAssets.logo.url` is not set
- [ ] Verify logo renders `<img>` when `drupalSettings.canvasData.v0.themeAssets.logo.url` is set to a URL
- [ ] Run `npm run code:check` — lint and Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)