### PR TITLE
fix(search): add missing aria-labels to search and close icon buttons

### DIFF
--- a/examples/components/search_button/index.jsx
+++ b/examples/components/search_button/index.jsx
@@ -12,6 +12,7 @@ const SearchButton = ({ positionTop = 50 }) => {
       <button
         type="button"
         aria-label={open ? 'Close' : 'Search'}
+        aria-expanded={open}
         className="rounded bg-blue-600 p-2.5 text-white"
         onClick={toggleOpen}
       >

--- a/examples/components/search_button/index.jsx
+++ b/examples/components/search_button/index.jsx
@@ -11,6 +11,7 @@ const SearchButton = ({ positionTop = 50 }) => {
     <>
       <button
         type="button"
+        aria-label={open ? 'Close' : 'Search'}
         className="rounded bg-blue-600 p-2.5 text-white"
         onClick={toggleOpen}
       >
@@ -36,6 +37,7 @@ const SearchOverlay = ({ positionTop }) => {
 const SearchIcon = () => {
   return (
     <svg
+      aria-hidden="true"
       className="h-4 w-4 stroke-white text-white"
       width="24"
       height="24"
@@ -62,6 +64,7 @@ const SearchIcon = () => {
 const CloseIcon = () => {
   return (
     <svg
+      aria-hidden="true"
       className="h-4 w-4 stroke-white text-white"
       width="24"
       height="20"

--- a/examples/components/search_form/index.jsx
+++ b/examples/components/search_form/index.jsx
@@ -22,9 +22,11 @@ export default function SearchForm({ className }) {
       </div>
       <button
         type="submit"
+        aria-label="Search"
         className="rounded bg-blue-600 p-2.5 leading-0 text-white"
       >
         <svg
+          aria-hidden="true"
           className="h-4 w-4 stroke-white text-white"
           width="24"
           height="24"


### PR DESCRIPTION
## Summary
  - Updates `examples/components/search_button/index.jsx` to add `aria-label` that toggles between `"Search"` and `"Close"` based on open state
  - Updates `examples/components/search_form/index.jsx` to add `aria-label="Search"` on the submit button
  - Adds `aria-hidden="true"` to decorative SVG icons in both components so screen readers only announce the button label

  ## Test plan
  - [ ] Verify search toggle button announces "Search, button" when closed
  - [ ] Verify search toggle button announces "Close, button" when open
  - [ ] Verify search form submit button announces "Search, button"
  - [ ] Run `npm run code:check` — lint and Prettier pass

  🤖 Generated with Claude Code
