### PR TITLE
feat(examples): add playback control props to video component

### DIFF
--- a/examples/components/video/component.yml
+++ b/examples/components/video/component.yml
@@ -12,4 +12,42 @@ props:
         - src: /ui/assets/videos/mountain_wide.mp4
           poster: https://placehold.co/1920x1080.png?text=Widescreen
       $ref: json-schema-definitions://canvas.module/video
+    showControls:
+      title: Show Controls
+      type: boolean
+      examples:
+        - true
+    autoplay:
+      title: Autoplay
+      type: boolean
+      examples:
+        - false
+    loop:
+      title: Loop
+      type: boolean
+      examples:
+        - false
+    muted:
+      title: Muted
+      type: boolean
+      examples:
+        - false
+    playsInline:
+      title: Plays Inline
+      type: boolean
+      examples:
+        - false
+    preload:
+      title: Preload
+      type: string
+      enum:
+        - none
+        - metadata
+        - auto
+      meta:enum:
+        none: None
+        metadata: Metadata
+        auto: Auto
+      examples:
+        - metadata
 slots: []

--- a/examples/components/video/index.jsx
+++ b/examples/components/video/index.jsx
@@ -1,6 +1,23 @@
-const Video = ({ video }) => {
+const Video = ({
+  video,
+  showControls = true,
+  autoplay = false,
+  loop = false,
+  muted = false,
+  playsInline = false,
+  preload = 'metadata',
+}) => {
   return (
-    <video className="w-full" controls>
+    <video
+      className="w-full"
+      controls={showControls}
+      autoPlay={autoplay}
+      loop={loop}
+      muted={muted}
+      playsInline={playsInline}
+      preload={preload}
+      poster={video.poster}
+    >
       <source src={video.src} />
       <track kind="captions" />
     </video>

--- a/examples/components/video/mocks.json
+++ b/examples/components/video/mocks.json
@@ -8,6 +8,21 @@
           "poster": "https://placehold.co/1920x1080.png?text=Widescreen"
         }
       }
+    },
+    {
+      "name": "Autoplay background loop",
+      "props": {
+        "video": {
+          "src": "https://www.w3schools.com/html/mov_bbb.mp4",
+          "poster": "https://placehold.co/1920x1080.png?text=Widescreen"
+        },
+        "showControls": false,
+        "autoplay": true,
+        "loop": true,
+        "muted": true,
+        "playsInline": true,
+        "preload": "auto"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

The video example component hardcoded `controls` and ignored every other `<video>` element attribute, including the `poster` already present in its schema examples. This adds Canvas-editable props for playback behavior:

- `showControls` (boolean, default true) — maps to `controls`
- `autoplay`, `loop`, `muted`, `playsInline` (booleans, default false)
- `preload` (enum: `none` / `metadata` / `auto`, default `metadata`)
- `poster` now renders from the existing `video` object

Defaults preserve the previous rendered output. Only `video` remains required.

## Mocks

Added an "Autoplay background loop" mock (muted, looping, no controls, plays inline). Muted is required for browser autoplay policies to allow playback.

## Validation

`npm run code:fix` passes for the changed files. The remaining ESLint error in `examples/components/accordion-item/index.jsx` exists on `main` and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)